### PR TITLE
Added pre-commit git hook to detect secrets

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Install detect-secrets if not found
+if ! command -v detect-secrets &> /dev/null
+then
+    echo "detect-secrets could not be found. Installing detect-secrets..."
+    if ! command -v pip3 &> /dev/null
+    then
+      pip install git+https://github.com/Contrast-Labs/detect-secrets
+    else
+      pip3 install git+https://github.com/Contrast-Labs/detect-secrets
+    fi
+fi
+
+# Generate secrets baseline if not found
+if [ -f ".secrets.baseline" ]; then
+  FILES=$(git diff --cached --name-only --diff-filter=ACM)
+  detect-secrets-hook --baseline .secrets.baseline "$FILES"
+else
+  echo "Warning: no .secrets.baseline found"
+fi
+
+# Install pre-commit if not found
+if ! command -v pre-commit &> /dev/null
+then
+    echo "pre-commit could not be found. Installing detect-secrets..."
+    if ! command -v brew &> /dev/null
+    then
+      pip install pre-commit
+    else
+      brew install pre-commit
+    fi
+fi
+
+echo "[INFO] If you encounter any issues with detect-secrets, please refer to https://github.com/Contrast-Labs/detect-secrets"
+
+pre-commit run
+
+exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  -   repo: https://github.com/Contrast-Labs/detect-secrets
+      rev: v1.1.2
+      hooks:
+        -   id: detect-secrets
+            name: Detect secrets
+            language: python
+            entry: detect-secrets-hook
+            args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,132 @@
+{
+  "version": "1.1.2",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "contrast_security.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "contrast_security.yml",
+        "hashed_secret": "89e495e7941cf9e40e6980d14a16bf023ccd4c91",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "contrast_security.yml",
+        "hashed_secret": "2ef26d13b6c2974c4f6678773bf88ed8917abae6",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "test/certs/server.key": [
+      {
+        "type": "Private Key",
+        "filename": "test/certs/server.key",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ]
+  },
+  "generated_at": "2021-11-16T14:08:04Z"
+}

--- a/package.json
+++ b/package.json
@@ -11,12 +11,17 @@
     "example/template.js"
   ],
   "scripts": {
+    "preinstall": "cp .githooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
     "test": "mocha 'test/**/*.test.js'",
     "test:cov": "nyc mocha $(find test -name '*.test.js')",
     "log-processor": "node ./lib/log-processor/index.js"
   },
   "keywords": [
-    "metrics", "performance", "measurement", "web", "server"
+    "metrics",
+    "performance",
+    "measurement",
+    "web",
+    "server"
   ],
   "author": "Contrast Security, Inc.",
   "contributors": [


### PR DESCRIPTION
This PR is adding a pre-commit hook that can detect if secrets are committed by mistake. To enable this git hook, run `npm install` and the `preinstall` hook will enable it.

It works for unix only. If you are on Windows, copy the `pre-commit` file from `.githooks/pre-commit` to `.git/hooks/pre-commit` manually.