### PR TITLE
Node 3074 node 16.19.1 updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
   "configurations": [
     {
       "name": "simple",
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
@@ -16,21 +16,21 @@
     },
     {
       "name": "server[agent]",
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
       ],
       "runtimeArgs": [
         "-r", "${workspaceFolder}",
-        "-r", "@contrast/agent"
+        "-r", "${input:agent}"
       ],
       "args": ["${input:args}"],
       "program": "${workspaceFolder}/test/servers/${input:server}"
     },
     {
       "name": "current file",
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
@@ -53,11 +53,11 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "type": "pwa-node"
+      "type": "node"
     },
     {
       "name": "current[custom]",
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
@@ -80,6 +80,15 @@
     "options": [
       "simple",
       "express"
+    ]
+  }, {
+    "id": "agent",
+    "type": "pickString",
+    "description": "agent to run",
+    "options": [
+      "@contrast/agent",
+      "@contrast/rasp-v3",
+      "@contrast/protect-agent"
     ]
   }]
 }

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ log file, `route-metrics.log` by default.
 
 Once the `route-metrics` agent has been used to generate a log file, it's
 useful to do something with the output. The included log-processor can be
-executed via `npx --package @contrast/route-metrics log-processor`.
-So to process the default log file, use `npx --package @contrast/route-metrics log-processor route-metrics.log`.
+executed via `npm run log-processor` and will look for the default log file
+in the current directory, `./route-metrics.log`. To specify a different log
+file or location, `npm run log-processor dir/other-file-name.log`.
 
 The log processor will read the log file, output some informational text,
 and use the requested reporter to write the output.
@@ -77,7 +78,7 @@ sampled internally by node; the setting is in milliseconds.
 
 The `route-metrics` log processor is also configured via environment variables.
 
-- `CSI_RM_REPORTER=csv`   # json is also a valid reporter. the json reporter is just a dump of the raw data.
+- `CSI_RM_REPORTER=csv`   # json is also valid. the json reporter is a formatted dump of the raw data.
 - `CSI_RM_OUTPUT=1`       # if numeric writes to that file descriptor, else writes to that file name.
 - `CSI_RM_TEMPLATE`       # a template that defines how the output is grouped
 - `CSI_RM_MICROSECONDS`   # report times in microseconds instead of milliseconds. (json reporter

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `route-metrics` log processor is also configured via environment variables.
 - `CSI_RM_OUTPUT=1`       # if numeric writes to that file descriptor, else writes to that file name.
 - `CSI_RM_TEMPLATE`       # a template that defines how the output is grouped
 - `CSI_RM_MICROSECONDS`   # report times in microseconds instead of milliseconds. (json reporter
-always reports raw data, i.e., microseconds.)
+always reports raw data, i.e., microseconds or, in the case of the eventloop delay, nanoseconds.)
 
 ## using a template
 

--- a/contrast_security.yaml
+++ b/contrast_security.yaml
@@ -12,7 +12,7 @@ agent:
   logger:
     level: debug
   service:
-    enable: true
+    enable: false
     grpc: true
     logger:
       path: speedracer.log

--- a/example/template.js
+++ b/example/template.js
@@ -15,7 +15,7 @@ module.exports = {
   labels: {
     title: 'this is my test server'
   },
-  // map routes that match the regex to the specified name. a route can
+  // group routes that match the regex and method as the specified name. a route can
   // match more than one regex.
   routes: [
     {name: 'noecho (ALL PARAMS)', method: 'POST', regex: /^\/noecho(\?.+)?/},

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,14 +67,14 @@ patchEmitter.on('patch', patchListener);
 metricsEmitter.on('metrics', metricsListener);
 
 const timeSeriesOptions = {tsCallback};
-if (config.GARBAGE_COLLECTION || config.EVENTLOOP) {
-  if (config.GARBAGE_COLLECTION) {
-    timeSeriesOptions.gcCallback = gcListener;
-  }
-  if (config.EVENTLOOP) {
-    timeSeriesOptions.elCallback = elListener;
-  }
+
+if (config.GARBAGE_COLLECTION) {
+  timeSeriesOptions.gcCallback = gcListener;
 }
+if (config.EVENTLOOP) {
+  timeSeriesOptions.elCallback = elListener;
+}
+
 // undocumented intervals primarily for testing.
 let interval = process.env.CSI_ROUTE_METRICS_TIME_SERIES_INTERVAL || 1000;
 interval = Number(interval);

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -26,9 +26,9 @@ for (let i = 0; i < patchers.length; i++) {
   }
 }
 
-// add a special entry just to watch whether the agent's been
-// loaded. this will result in a 'patch' entry in the log file
-// when the agent is loaded.
+// add a special entry just to watch whether the agent's been loaded. this will
+// result in a 'patch' entry in the log file when the agent is loaded, even though
+// it's not really patched.
 patchmap.set('@contrast/agent', {
   name: '@contrast/agent',
   isPatched: false,
@@ -36,6 +36,24 @@ patchmap.set('@contrast/agent', {
     return m;
   }
 });
+
+// node 16.19.1 made -r @contrast/agent not accessible via require patching, so look at
+// execArgv when we get the first require call starting with @contrast.
+// https://github.com/nodejs/node/commit/b02d895137
+let emitOnFirstContrastLoad;
+
+const [major, minor, patch] = process.versions.node.split('.');
+if (major > 16 || (major == 16 && minor > 19) || (major == 16 && minor == 19 && patch > 0)) {
+  const AGENTS = ['@contrast/agent', '@contrast/protect-agent', '@contrast/rasp-v3'];
+  for (let i = 0; i < process.execArgv.length; i++) {
+    if (['-r', '--require'].includes(process.execArgv[i])) {
+      const ix = AGENTS.indexOf(process.execArgv[i + 1]);
+      if (ix >= 0) {
+        emitOnFirstContrastLoad = AGENTS[ix];
+      }
+    }
+  }
+}
 
 /**
  * @function patcher
@@ -50,6 +68,12 @@ patchmap.set('@contrast/agent', {
  */
 function patcher(name) {
   const m = Require.call(this, name);
+
+  if (emitOnFirstContrastLoad && name.startsWith('@contrast')) {
+    emitter.emit('patch', {name: emitOnFirstContrastLoad});
+    emitOnFirstContrastLoad = undefined;
+    return m;
+  }
 
   // if it's not present then we don't want to patch it.
   const patchInfo = patchmap.get(name);

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -6,6 +6,7 @@ const path = require('path');
 
 const Require = module.constructor.prototype.require;
 
+const AGENTS = ['@contrast/agent', '@contrast/protect-agent', '@contrast/rasp-v3'];
 const patchmap = new Map();
 const emitter = new Emitter();
 
@@ -26,17 +27,6 @@ for (let i = 0; i < patchers.length; i++) {
   }
 }
 
-// add a special entry just to watch whether the agent's been loaded. this will
-// result in a 'patch' entry in the log file when the agent is loaded, even though
-// it's not really patched.
-patchmap.set('@contrast/agent', {
-  name: '@contrast/agent',
-  isPatched: false,
-  patcher(m) {
-    return m;
-  }
-});
-
 // node 16.19.1 made -r @contrast/agent not accessible via require patching, so look at
 // execArgv when we get the first require call starting with @contrast.
 // https://github.com/nodejs/node/commit/b02d895137
@@ -44,7 +34,6 @@ let emitOnFirstContrastLoad;
 
 const [major, minor, patch] = process.versions.node.split('.');
 if (major > 16 || (major == 16 && minor > 19) || (major == 16 && minor == 19 && patch > 0)) {
-  const AGENTS = ['@contrast/agent', '@contrast/protect-agent', '@contrast/rasp-v3'];
   for (let i = 0; i < process.execArgv.length; i++) {
     if (['-r', '--require'].includes(process.execArgv[i])) {
       const ix = AGENTS.indexOf(process.execArgv[i + 1]);
@@ -52,6 +41,19 @@ if (major > 16 || (major == 16 && minor > 19) || (major == 16 && minor == 19 && 
         emitOnFirstContrastLoad = AGENTS[ix];
       }
     }
+  }
+} else {
+  // add a special entry just to watch whether the agent's been loaded. this will
+  // result in a 'patch' entry in the log file when the agent is loaded, even though
+  // it's not really patched.
+  for (const agent of AGENTS) {
+    patchmap.set(agent, {
+      name: agent,
+      isPatched: false,
+      patcher(m) {
+        return m;
+      }
+    });
   }
 }
 
@@ -62,6 +64,9 @@ if (major > 16 || (major == 16 && minor > 19) || (major == 16 && minor == 19 && 
  * module is required, patcher is invoked. it uses the original require function
  * to load the module and, if the module is in the patch map, invokes the code to
  * patch the module.
+ *
+ * N.B. as of node 16.19.1 this will not be invoked when node internally loads a
+ * module via '-r' or '--require' on the command line (and possibly other situations).
  *
  * @param {string} name name of the module to be loaded
  * @returns {object} the loaded module, possibly patched
@@ -105,5 +110,6 @@ patcher.getPatchMap = function() {
 
 module.exports = {
   patcher,
-  emitter
+  emitter,
+  AGENTS,
 };

--- a/lib/patcher.test.js
+++ b/lib/patcher.test.js
@@ -6,6 +6,8 @@ const Require = module.constructor.prototype.require;
 
 const {patcher, emitter} = require('./patcher');
 
+const patchableRequire = semver.lt(process.version, '16.19.1');
+
 describe('patcher', function() {
   let patchmap;
   let originalPatchMap;
@@ -24,13 +26,37 @@ describe('patcher', function() {
     emitter.removeAllListeners();
   });
 
-  it('http, https, and @contrast/agent should be patchable', function() {
-    ['http', 'https', '@contrast/agent'].forEach(m => {
+  const whenPatchable = patchableRequire ? it : it.skip;
+  const whenNotPatchable = patchableRequire ? it.skip : it;
+
+  it('http, https should be in patchmap', function() {
+    ['http', 'https'].forEach(m => {
       const has = patchmap.has(m);
       const is = patchmap.get(m);
       expect(has).equal(true, `${m} should be in the patchmap`);
       expect(is).property('name').equal(m);
       expect(is).property('isPatched').equal(false, `${m} should not be patched`);
+    });
+  });
+
+  whenPatchable('@contrast/agents should be in patchmap', function() {
+    ['@contrast/agent', '@contrast/protect-agent', '@contrast/rasp-v3'].forEach(m => {
+      const has = patchmap.has(m);
+      const is = patchmap.get(m);
+      expect(has).equal(true, `${m} should be in the patchmap`);
+      expect(is).property('name').equal(m);
+      expect(is).property('isPatched').equal(false, `${m} should not be patched`);
+    });
+  });
+
+
+  whenNotPatchable('@contrast/agents should not be in patchmap', function() {
+    ['agent', 'protect-agent', 'rasp-v3'].forEach(m => {
+      const name = `@contrast/${m}`;
+      const has = patchmap.has(name);
+      const is = patchmap.get(name);
+      expect(has).equal(false, `${name} should not be in the patchmap`);
+      expect(is).equal(undefined, `${name} should not be in the patchmap`);
     });
   });
 

--- a/lib/time-series/index.js
+++ b/lib/time-series/index.js
@@ -160,6 +160,7 @@ class TimeSeries {
   }
 
   enableEventloopMonitoring(options) {
+    // eventloop delay is in nanoseconds
     return perf_hooks.monitorEventLoopDelay(options);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
       },
       "devDependencies": {
         "@contrast/agent": "^4.32.13",
+        "@contrast/protect-agent": "^5.7.0",
+        "@contrast/rasp-v3": "^0.5.0",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "eslint": "^7.32.0",
@@ -121,14 +123,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
+      "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.22.5",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -161,39 +164,35 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
       "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -282,21 +281,30 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -326,12 +334,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -363,9 +371,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -375,44 +383,45 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
+      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.8",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.8",
-        "@babel/types": "^7.14.8",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.7",
+        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.7",
+        "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -421,12 +430,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -465,12 +474,13 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -548,6 +558,18 @@
       "dependencies": {
         "@node-rs/helper": "^1.2.1"
       }
+    },
+    "node_modules/@contrast/agent-swc-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-swc-plugin/-/agent-swc-plugin-1.1.0.tgz",
+      "integrity": "sha512-kjHHAdB6FTeubQAveIDuxjqlxYvhxaURBbOm4f3Nb0LGFs2pua7WHBnYUPehnDQxIRuqCdzDx8qmtaSM0oD4zA==",
+      "dev": true
+    },
+    "node_modules/@contrast/agent-swc-plugin-unwrite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-swc-plugin-unwrite/-/agent-swc-plugin-unwrite-1.1.0.tgz",
+      "integrity": "sha512-Y9mFhTf9jiOA61JYaJmTr/YL87/wjw7gNn27s7Y7F4O0wLVWfCUQjCrros/gTbRRw8R10E/RcYP3kM9Jw+iSaQ==",
+      "dev": true
     },
     "node_modules/@contrast/agent/node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -926,6 +948,121 @@
         "node": ">= 6.4.0"
       }
     },
+    "node_modules/@contrast/agentify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agentify/-/agentify-1.6.0.tgz",
+      "integrity": "sha512-Cm/abjhY4v8zRPY/2rRl0HO0HixxN6nlaqb4FoBZDeegIOq0hJ+u8w6fDcUDAf5A7W1sWwkgQ9YHDo/u/ZwlCg==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/architecture-components": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@contrast/architecture-components/-/architecture-components-1.6.0.tgz",
+      "integrity": "sha512-b43aOaRAYfxBKtxGCHxndM16wWOd00xyboUA8diNzjujZMT7XW+hZmbUu0SFHc/0BKJDaKqGzy/PpCFAJgR86A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/assess": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/assess/-/assess-1.5.0.tgz",
+      "integrity": "sha512-C+oZLt1RUyAtot6WXDFGKnXAVb9k0Dh5vK1bKiXypJ/Po9xKrldrOnjGc5AIbBJ0taH6t3MAD/mOuHC3uSNdZw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0",
+        "@contrast/distringuish": "^4.1.0",
+        "@contrast/scopes": "1.3.0",
+        "parseurl": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/common": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@contrast/common/-/common-1.8.0.tgz",
+      "integrity": "sha512-2xc/AsdA+sa9TLrKgyn2kIN6jISeeGfR7FNMQtlnq0xaepuWjcp4W9muRZNOxgwhsjOGVIb/DvPze0CQ+OhYkA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/config": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@contrast/config/-/config-1.10.0.tgz",
+      "integrity": "sha512-6LQ7yfxSmecGhmtdnnGaMmKxTTn+wyLehdZZPxJ5fBGFx/HLNOoZxGUZfQQomddENhyjX3MOTi1JDlI60W4f2w==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0",
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/core": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@contrast/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-t/9x+X11m8mLCRtznDKg8awUssEYfdmlZrYr/FO1B+ZN09OLW562olQXo4vfgKRTVTqt2RDFqtfwKPBtDPceBg==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/agentify": "1.6.0",
+        "@contrast/common": "1.8.0",
+        "@contrast/config": "1.10.0",
+        "@contrast/deadzones": "1.1.0",
+        "@contrast/dep-hooks": "1.1.0",
+        "@contrast/fn-inspect": "^3.2.0",
+        "@contrast/instrumentation": "1.1.1",
+        "@contrast/logger": "1.3.0",
+        "@contrast/patcher": "1.3.0",
+        "@contrast/reporter": "1.13.0",
+        "@contrast/rewriter": "1.4.0",
+        "@contrast/scopes": "1.3.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/deadzones": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/deadzones/-/deadzones-1.1.0.tgz",
+      "integrity": "sha512-jU0qk2NmUwK/ZmpbLjyu4GXOH9Wq6YWj0HHiMYrHmWXcs7zoP7hq/AvrisNzBzGxIQbFg1aFpqJpeHidWyqG3A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/dep-hooks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/dep-hooks/-/dep-hooks-1.1.0.tgz",
+      "integrity": "sha512-mtfTHDSW1OX9iL3Xnf0b3PLWG1Nkk9omnfR8dSyekfrmvfnCgXIeMmK7oQj1u2wFeijmT4JX8ECtW/vYiB2jkg==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/require-hook": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
     "node_modules/@contrast/distringuish": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@contrast/distringuish/-/distringuish-4.3.0.tgz",
@@ -939,6 +1076,20 @@
       },
       "engines": {
         "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@contrast/esm-hooks": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@contrast/esm-hooks/-/esm-hooks-1.11.0.tgz",
+      "integrity": "sha512-JAeNzZJUwnf0uWHjrqtHIcHI5Vhlpj565x9u6I6xSuNDJdQ55nTeW27OrR20FvGFXOYufOIys/UJ6fIJ9uvb2Q==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/core": "1.15.0",
+        "parent-package-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
       }
     },
     "node_modules/@contrast/flat": {
@@ -961,6 +1112,177 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/@contrast/instrumentation": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@contrast/instrumentation/-/instrumentation-1.1.1.tgz",
+      "integrity": "sha512-C1boEz2UJLOQq7j+A6/clRBcWttWrLlw0S6iLSnatASOiGt9BE0Q7G6Pp7v6giwHPyE29gB9uK11s0J+tLrTrA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/library-analysis": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/library-analysis/-/library-analysis-1.4.0.tgz",
+      "integrity": "sha512-m36aoWplaRr/YUYZ8GSNdfPtZH/6miaQE/V46ZaX33ogjvv1DJO9LSiWj4ZpxEXBAQ8Kbmc9Y6ahUN2jAX3oiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0",
+        "@contrast/fn-inspect": "3.3.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/library-analysis/node_modules/@contrast/fn-inspect": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+      "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@contrast/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-z6s1Axvc1Hl1ORCyJOJOdGiWnskslSLS1wVOtNur71Yge4pj6W8xqjlh9hrOI7s//fdCftCr4+2RBfflqpu4jg==",
+      "dev": true,
+      "dependencies": {
+        "pino": "^7.10.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/patcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/patcher/-/patcher-1.3.0.tgz",
+      "integrity": "sha512-Zs26rkz++snlINaRqfBKINcHZn59cGg5hXc0X5fimJ7oQRcNdYz5c4ay5uf5okF66NeEx471CrHAxseVz5TPOw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/protect": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@contrast/protect/-/protect-1.17.0.tgz",
+      "integrity": "sha512-vTu+1jU90zuHYTwcj6iu6nw373p5hSrJj/A8m9ckDqlAHlaick/4Pc6/PuCWiHYmpYMmywhDqpt8bAq+9teBFw==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/agent-lib": "^5.3.4",
+        "@contrast/common": "1.8.0",
+        "@contrast/core": "1.15.0",
+        "@contrast/esm-hooks": "1.11.0",
+        "@contrast/scopes": "1.3.0",
+        "ipaddr.js": "^2.0.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">= 8.4.0"
+      },
+      "optionalDependencies": {
+        "async-hook-domain": "^3.0.2"
+      }
+    },
+    "node_modules/@contrast/protect-agent": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@contrast/protect-agent/-/protect-agent-5.7.0.tgz",
+      "integrity": "sha512-4xTgTylnUQcEdcQcWlwI4/RwpMPitZe5BEUOCAyYHMk8vdYSbPGoS8Wd0aY47VDfKCqvUCGoqtDpHckghCWd4w==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/cli": "1.6.0",
+        "@contrast/core": "1.15.0",
+        "@contrast/protect": "1.17.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=14.15.0 <15 || >=16.9.1 <17 || >=18.7.0 <19",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/protect-agent/node_modules/@contrast/agent": {
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-PMscJ1piadnB1GQ6Acy7Z6NbRxU9mlo9Va9FU0D8QzjCbtmzfaZN419XMUJnUqb28m2CwJX1NGoIwjn9vfgd/Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@contrast/architecture-components": "1.6.0",
+        "@contrast/assess": "1.5.0",
+        "@contrast/core": "1.15.0",
+        "@contrast/library-analysis": "1.4.0",
+        "@contrast/protect": "1.17.0",
+        "@contrast/route-coverage": "1.4.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=14.15.0 <15 || >=16.9.1 <17 || >=18.7.0 <19",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/protect-agent/node_modules/@contrast/cli": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@contrast/cli/-/cli-1.6.0.tgz",
+      "integrity": "sha512-85cIr+1EGNr/XtdPli8wkjXc3jSEpm0WTUstTehphRf6ptIvsW0+zNb9oqtPQz4PI/js/uteGQ91Zdnst8LjHw==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/core": "1.15.0",
+        "commander": "^9.4.1"
+      },
+      "bin": {
+        "config-diagnostics": "lib/config-diagnostics.js",
+        "system-diagnostics": "lib/system-diagnostics.js"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      },
+      "peerDependencies": {
+        "@contrast/agent": "5.0.0-alpha.6",
+        "@contrast/protect-agent": "5.7.0"
+      }
+    },
+    "node_modules/@contrast/protect-agent/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@contrast/protect/node_modules/@contrast/agent-lib": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
+      "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      }
+    },
+    "node_modules/@contrast/protect/node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@contrast/protobuf-api": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.6.tgz",
@@ -969,6 +1291,59 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.5.3",
         "google-protobuf": "^3.11.4"
+      }
+    },
+    "node_modules/@contrast/rasp-v3": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.5.0.tgz",
+      "integrity": "sha512-nkxfl6AEqJcYTjpOltDkifyzlze7DC/Onyf2mNuN1wwEOClwb8b0Oa0R9/VY+6LpdE5SSzkLGpc+fPKVYj46Rw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.19.0",
+        "@babel/parser": "^7.19.1",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.1",
+        "@babel/types": "^7.19.0",
+        "@contrast/agent-lib": "^5.2.1",
+        "@contrast/distringuish": "^4.1.0",
+        "@contrast/require-hook": "^3.2.1"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/@contrast/agent-lib": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
+      "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      }
+    },
+    "node_modules/@contrast/reporter": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@contrast/reporter/-/reporter-1.13.0.tgz",
+      "integrity": "sha512-TbY0Qyjkux7A3KKqYwOq6bt9IJcjp2FycldaV4c1BNpQHCkL4aB8ChlVmMhr4zxvcNidiKe4Bm7pvjnb11VDag==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0",
+        "axios": "^0.27.2",
+        "crc-32": "^1.2.2",
+        "hpagent": "^1.2.0",
+        "safe-stable-stringify": "^2.4.1",
+        "sonic-boom": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/reporter/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@contrast/require-hook": {
@@ -984,10 +1359,51 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/@contrast/rewriter": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/rewriter/-/rewriter-1.4.0.tgz",
+      "integrity": "sha512-YBfJCdZuQlXHtZN9VS850mXcYZ4vw2e020uIkd2sH8QbvUZ9ipIWDFkBYSCT4eFHen/jtI+sJGzVMGym3sWyJw==",
+      "dev": true,
+      "dependencies": {
+        "@contrast/agent-swc-plugin": "^1.1.0",
+        "@contrast/agent-swc-plugin-unwrite": "^1.1.0",
+        "@contrast/synchronous-source-maps": "^1.1.3",
+        "@swc/core": "1.3.39",
+        "multi-stage-sourcemap": "^0.3.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/route-coverage": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/route-coverage/-/route-coverage-1.4.0.tgz",
+      "integrity": "sha512-QxEbiGrncJ73159npqw+zYkcuNAX87yaRabtgwixhfO9ArEwMCWM4K0coLSZyt9uwY6AihmbRVbm2SlN7iqhcg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@contrast/common": "1.8.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/scopes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/scopes/-/scopes-1.3.0.tgz",
+      "integrity": "sha512-TrXIawA69HoaHY46uPbgkqMe/F/5L2jhcIaRh75U8PCH6VhXt0J1QPa0pxEm9WzFRltrgbowLq8SYyR60IFuPA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.15.0",
+        "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
     "node_modules/@contrast/synchronous-source-maps": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/synchronous-source-maps/-/synchronous-source-maps-1.1.0.tgz",
-      "integrity": "sha512-oTJxcpgyFgmO/UTvpn4zeypnbhYpskI5VrR+mXIzV47BhRgRX5f9PNsevv+wfV41/SUVTPc3V0+kq0ZZRYVDkg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@contrast/synchronous-source-maps/-/synchronous-source-maps-1.1.5.tgz",
+      "integrity": "sha512-bi2ygCv6y60CzQ/kiGX4pEwViUTcC+mzWzPQCHwaso7Cm/VPHel027BUbOym/u3nD5VSd+wPrefplXqNZb9JYg==",
       "dev": true,
       "dependencies": {
         "source-map": "^0.7.3"
@@ -1256,6 +1672,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
     "node_modules/@napi-rs/triples": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.1.0.tgz",
@@ -1369,6 +1839,192 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@swc/core": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.39.tgz",
+      "integrity": "sha512-r5oIySPo2OkC14+gmhK5H1HnDEgOvj5kx6Ogxa+Og7KyWIHE8l1JjjW+4wzYdjxtdhRjVRhvoI6mPQNQz/btBg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.3.39",
+        "@swc/core-darwin-x64": "1.3.39",
+        "@swc/core-linux-arm-gnueabihf": "1.3.39",
+        "@swc/core-linux-arm64-gnu": "1.3.39",
+        "@swc/core-linux-arm64-musl": "1.3.39",
+        "@swc/core-linux-x64-gnu": "1.3.39",
+        "@swc/core-linux-x64-musl": "1.3.39",
+        "@swc/core-win32-arm64-msvc": "1.3.39",
+        "@swc/core-win32-ia32-msvc": "1.3.39",
+        "@swc/core-win32-x64-msvc": "1.3.39"
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.39.tgz",
+      "integrity": "sha512-qYR47BEfUvK1WRAP/LVbHakCo4mcksgDjRutJbkx3maTgHlSGYQKCQo7hz+or+n3cbR2abY0rFEgoCLjZctGOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.39.tgz",
+      "integrity": "sha512-kqJ8OleY/y3S+HXnZxDWFVbKpRsb7gZDZr6Pksr8tzFba/6pLkZFBxds/zgfWIlUwri2Lcx0X872MJ46ghwv9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.39.tgz",
+      "integrity": "sha512-+c3A2BV0esPNHn/KKMqP+bphUF86sVKUIaxn5tKMDrnO8ckOpEMbJ+SwzYLtwC9JIYjWwryg/0yvWrdma26Irw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.39.tgz",
+      "integrity": "sha512-IRrfft7ANk3NR0qX6bXbfkqbT+WR0TMvgODQdZAtRQIt5ERFpdhcnYc4tlJzfV23R0Ek3kpdA8Gduj4tHk0K6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.39.tgz",
+      "integrity": "sha512-N8tnynqBdRzY8m2blPAnLUtaln0m8gb96q6ipnY+XoHQ3Z6uZoUq8jWAeFDhD+MCzM7qD2HyBDN7sEqiwMRO/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.39.tgz",
+      "integrity": "sha512-Jif56kWHOjQexCib4FVbGeUcBUc56cgNW7ELEKAUCID70z20JHMVTd5utcmfi1L9tywGMvfzqD5z+NQtrFV8GQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.39.tgz",
+      "integrity": "sha512-ZiGERr/mdsEwfSiWn2Qokd8a4TTJkLVta6Nan39Bozo6J789u4uDF9Cj5TWWMSanHYAK/oRDaUm1yo2/DSecAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.39.tgz",
+      "integrity": "sha512-eUAk12LZ6RQHhe0ikZZsi0CPbRA6qsvoNQQ/6uwVF60CT0UnJrLiX3w3q30aXK3WjVR6uUlVEn7ze5t7HUeGyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.39.tgz",
+      "integrity": "sha512-c3MIt+0gvZD0hmPOyoIJtdgx1ubP7E+uUnljw2+Nk8rO6qhIrWI08tWRNbT0HNLXHfHhKMJHvSAg3DGW8vG3Rg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.39.tgz",
+      "integrity": "sha512-c4xGToLavhHjrE0Um0GyXCilL3sKNRP71GgQTVvqTFHxMmdUCBdug28olMDE1gYsCqXHaF6rPtg3QmD6dhTzKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -1607,6 +2263,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/async-hook-domain": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-3.0.2.tgz",
+      "integrity": "sha512-6nTkYKaKFtzR9mWv1kCGVpM4U2r30tQiuSbQuMMJyOCMKnPhg1JTYcJoPOR8RLsQgI/12NkE8FHi60gP3FzLBw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/async-hook-jl": {
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
@@ -1617,6 +2283,21 @@
       },
       "engines": {
         "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/axios": {
@@ -2022,6 +2703,18 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -2104,14 +2797,10 @@
       "dev": true
     },
     "node_modules/crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
-      "dependencies": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      },
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -2184,6 +2873,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2198,6 +2896,15 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -2218,6 +2925,61 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/ee-first": {
@@ -2254,6 +3016,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -2532,15 +3303,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2599,6 +3361,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -2734,6 +3505,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2966,6 +3751,15 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/html-escaper": {
@@ -4120,6 +4914,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "dev": true
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4308,6 +5108,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dev": true,
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+      "dev": true
+    },
+    "node_modules/pino/node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -4381,18 +5228,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-      "dev": true,
-      "bin": {
-        "printj": "bin/printj.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -4404,6 +5239,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4499,6 +5340,12 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4554,6 +5401,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/regexpp": {
@@ -4649,6 +5505,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4858,6 +5723,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/sonic-boom": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4884,6 +5758,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4904,6 +5787,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -5038,6 +5927,15 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "dev": true,
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5156,6 +6054,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -5326,6 +6230,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -5453,14 +6366,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
+      "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.22.5",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
       }
     },
     "@babel/helper-compilation-targets": {
@@ -5483,33 +6397,29 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      }
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
+      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "dev": true
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+    "@babel/helper-function-name": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
+      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.22.5",
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -5577,18 +6487,24 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.22.5"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-      "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -5609,12 +6525,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -5639,57 +6555,58 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
+      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.22.5",
+        "@babel/parser": "^7.22.5",
+        "@babel/types": "^7.22.5"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.22.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+          "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.22.5"
           }
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
+      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.8",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.8",
-        "@babel/types": "^7.14.8",
+        "@babel/code-frame": "^7.22.5",
+        "@babel/generator": "^7.22.7",
+        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.22.7",
+        "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.22.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+          "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.22.5"
           }
         },
         "debug": {
@@ -5716,12 +6633,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -6076,6 +6994,101 @@
         "@node-rs/helper": "^1.2.1"
       }
     },
+    "@contrast/agent-swc-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-swc-plugin/-/agent-swc-plugin-1.1.0.tgz",
+      "integrity": "sha512-kjHHAdB6FTeubQAveIDuxjqlxYvhxaURBbOm4f3Nb0LGFs2pua7WHBnYUPehnDQxIRuqCdzDx8qmtaSM0oD4zA==",
+      "dev": true
+    },
+    "@contrast/agent-swc-plugin-unwrite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-swc-plugin-unwrite/-/agent-swc-plugin-unwrite-1.1.0.tgz",
+      "integrity": "sha512-Y9mFhTf9jiOA61JYaJmTr/YL87/wjw7gNn27s7Y7F4O0wLVWfCUQjCrros/gTbRRw8R10E/RcYP3kM9Jw+iSaQ==",
+      "dev": true
+    },
+    "@contrast/agentify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agentify/-/agentify-1.6.0.tgz",
+      "integrity": "sha512-Cm/abjhY4v8zRPY/2rRl0HO0HixxN6nlaqb4FoBZDeegIOq0hJ+u8w6fDcUDAf5A7W1sWwkgQ9YHDo/u/ZwlCg==",
+      "dev": true,
+      "requires": {
+        "@contrast/common": "1.8.0"
+      }
+    },
+    "@contrast/architecture-components": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@contrast/architecture-components/-/architecture-components-1.6.0.tgz",
+      "integrity": "sha512-b43aOaRAYfxBKtxGCHxndM16wWOd00xyboUA8diNzjujZMT7XW+hZmbUu0SFHc/0BKJDaKqGzy/PpCFAJgR86A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@contrast/common": "1.8.0"
+      }
+    },
+    "@contrast/assess": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/assess/-/assess-1.5.0.tgz",
+      "integrity": "sha512-C+oZLt1RUyAtot6WXDFGKnXAVb9k0Dh5vK1bKiXypJ/Po9xKrldrOnjGc5AIbBJ0taH6t3MAD/mOuHC3uSNdZw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@contrast/common": "1.8.0",
+        "@contrast/distringuish": "^4.1.0",
+        "@contrast/scopes": "1.3.0",
+        "parseurl": "^1.3.3"
+      }
+    },
+    "@contrast/common": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@contrast/common/-/common-1.8.0.tgz",
+      "integrity": "sha512-2xc/AsdA+sa9TLrKgyn2kIN6jISeeGfR7FNMQtlnq0xaepuWjcp4W9muRZNOxgwhsjOGVIb/DvPze0CQ+OhYkA==",
+      "dev": true
+    },
+    "@contrast/config": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@contrast/config/-/config-1.10.0.tgz",
+      "integrity": "sha512-6LQ7yfxSmecGhmtdnnGaMmKxTTn+wyLehdZZPxJ5fBGFx/HLNOoZxGUZfQQomddENhyjX3MOTi1JDlI60W4f2w==",
+      "dev": true,
+      "requires": {
+        "@contrast/common": "1.8.0",
+        "yaml": "^2.2.2"
+      }
+    },
+    "@contrast/core": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@contrast/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-t/9x+X11m8mLCRtznDKg8awUssEYfdmlZrYr/FO1B+ZN09OLW562olQXo4vfgKRTVTqt2RDFqtfwKPBtDPceBg==",
+      "dev": true,
+      "requires": {
+        "@contrast/agentify": "1.6.0",
+        "@contrast/common": "1.8.0",
+        "@contrast/config": "1.10.0",
+        "@contrast/deadzones": "1.1.0",
+        "@contrast/dep-hooks": "1.1.0",
+        "@contrast/fn-inspect": "^3.2.0",
+        "@contrast/instrumentation": "1.1.1",
+        "@contrast/logger": "1.3.0",
+        "@contrast/patcher": "1.3.0",
+        "@contrast/reporter": "1.13.0",
+        "@contrast/rewriter": "1.4.0",
+        "@contrast/scopes": "1.3.0"
+      }
+    },
+    "@contrast/deadzones": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/deadzones/-/deadzones-1.1.0.tgz",
+      "integrity": "sha512-jU0qk2NmUwK/ZmpbLjyu4GXOH9Wq6YWj0HHiMYrHmWXcs7zoP7hq/AvrisNzBzGxIQbFg1aFpqJpeHidWyqG3A==",
+      "dev": true
+    },
+    "@contrast/dep-hooks": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/dep-hooks/-/dep-hooks-1.1.0.tgz",
+      "integrity": "sha512-mtfTHDSW1OX9iL3Xnf0b3PLWG1Nkk9omnfR8dSyekfrmvfnCgXIeMmK7oQj1u2wFeijmT4JX8ECtW/vYiB2jkg==",
+      "dev": true,
+      "requires": {
+        "@contrast/require-hook": "^3.2.1"
+      }
+    },
     "@contrast/distringuish": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@contrast/distringuish/-/distringuish-4.3.0.tgz",
@@ -6085,6 +7098,16 @@
         "nan": "^2.17.0",
         "node-addon-api": "^4.3.0",
         "node-gyp-build": "^4.5.0"
+      }
+    },
+    "@contrast/esm-hooks": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@contrast/esm-hooks/-/esm-hooks-1.11.0.tgz",
+      "integrity": "sha512-JAeNzZJUwnf0uWHjrqtHIcHI5Vhlpj565x9u6I6xSuNDJdQ55nTeW27OrR20FvGFXOYufOIys/UJ6fIJ9uvb2Q==",
+      "dev": true,
+      "requires": {
+        "@contrast/core": "1.15.0",
+        "parent-package-json": "^2.0.1"
       }
     },
     "@contrast/flat": {
@@ -6103,6 +7126,131 @@
         "node-gyp-build": "^4.4.0"
       }
     },
+    "@contrast/instrumentation": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@contrast/instrumentation/-/instrumentation-1.1.1.tgz",
+      "integrity": "sha512-C1boEz2UJLOQq7j+A6/clRBcWttWrLlw0S6iLSnatASOiGt9BE0Q7G6Pp7v6giwHPyE29gB9uK11s0J+tLrTrA==",
+      "dev": true
+    },
+    "@contrast/library-analysis": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/library-analysis/-/library-analysis-1.4.0.tgz",
+      "integrity": "sha512-m36aoWplaRr/YUYZ8GSNdfPtZH/6miaQE/V46ZaX33ogjvv1DJO9LSiWj4ZpxEXBAQ8Kbmc9Y6ahUN2jAX3oiw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@contrast/common": "1.8.0",
+        "@contrast/fn-inspect": "3.3.0",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "@contrast/fn-inspect": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.0.tgz",
+          "integrity": "sha512-iulijoAuhfamXZNWsEy4ORNd8TxqD6aKeMiukDpWSwuRJ3sB+4lOmY2DkP2WwlBpYMmh3k4/7LHP2I925Y2xKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "nan": "^2.16.0",
+            "node-gyp-build": "^4.4.0"
+          }
+        }
+      }
+    },
+    "@contrast/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-z6s1Axvc1Hl1ORCyJOJOdGiWnskslSLS1wVOtNur71Yge4pj6W8xqjlh9hrOI7s//fdCftCr4+2RBfflqpu4jg==",
+      "dev": true,
+      "requires": {
+        "pino": "^7.10.0"
+      }
+    },
+    "@contrast/patcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/patcher/-/patcher-1.3.0.tgz",
+      "integrity": "sha512-Zs26rkz++snlINaRqfBKINcHZn59cGg5hXc0X5fimJ7oQRcNdYz5c4ay5uf5okF66NeEx471CrHAxseVz5TPOw==",
+      "dev": true
+    },
+    "@contrast/protect": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@contrast/protect/-/protect-1.17.0.tgz",
+      "integrity": "sha512-vTu+1jU90zuHYTwcj6iu6nw373p5hSrJj/A8m9ckDqlAHlaick/4Pc6/PuCWiHYmpYMmywhDqpt8bAq+9teBFw==",
+      "dev": true,
+      "requires": {
+        "@contrast/agent-lib": "^5.3.4",
+        "@contrast/common": "1.8.0",
+        "@contrast/core": "1.15.0",
+        "@contrast/esm-hooks": "1.11.0",
+        "@contrast/scopes": "1.3.0",
+        "async-hook-domain": "^3.0.2",
+        "ipaddr.js": "^2.0.1",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "@contrast/agent-lib": {
+          "version": "5.3.5",
+          "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
+          "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^2.0.1"
+          }
+        },
+        "ipaddr.js": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+          "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+          "dev": true
+        }
+      }
+    },
+    "@contrast/protect-agent": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@contrast/protect-agent/-/protect-agent-5.7.0.tgz",
+      "integrity": "sha512-4xTgTylnUQcEdcQcWlwI4/RwpMPitZe5BEUOCAyYHMk8vdYSbPGoS8Wd0aY47VDfKCqvUCGoqtDpHckghCWd4w==",
+      "dev": true,
+      "requires": {
+        "@contrast/cli": "1.6.0",
+        "@contrast/core": "1.15.0",
+        "@contrast/protect": "1.17.0",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "@contrast/agent": {
+          "version": "5.0.0-alpha.6",
+          "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-5.0.0-alpha.6.tgz",
+          "integrity": "sha512-PMscJ1piadnB1GQ6Acy7Z6NbRxU9mlo9Va9FU0D8QzjCbtmzfaZN419XMUJnUqb28m2CwJX1NGoIwjn9vfgd/Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@contrast/architecture-components": "1.6.0",
+            "@contrast/assess": "1.5.0",
+            "@contrast/core": "1.15.0",
+            "@contrast/library-analysis": "1.4.0",
+            "@contrast/protect": "1.17.0",
+            "@contrast/route-coverage": "1.4.0",
+            "semver": "^7.3.7"
+          }
+        },
+        "@contrast/cli": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@contrast/cli/-/cli-1.6.0.tgz",
+          "integrity": "sha512-85cIr+1EGNr/XtdPli8wkjXc3jSEpm0WTUstTehphRf6ptIvsW0+zNb9oqtPQz4PI/js/uteGQ91Zdnst8LjHw==",
+          "dev": true,
+          "requires": {
+            "@contrast/core": "1.15.0",
+            "commander": "^9.4.1"
+          }
+        },
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "dev": true
+        }
+      }
+    },
     "@contrast/protobuf-api": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.6.tgz",
@@ -6111,6 +7259,59 @@
       "requires": {
         "@grpc/grpc-js": "^1.5.3",
         "google-protobuf": "^3.11.4"
+      }
+    },
+    "@contrast/rasp-v3": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.5.0.tgz",
+      "integrity": "sha512-nkxfl6AEqJcYTjpOltDkifyzlze7DC/Onyf2mNuN1wwEOClwb8b0Oa0R9/VY+6LpdE5SSzkLGpc+fPKVYj46Rw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.19.0",
+        "@babel/parser": "^7.19.1",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.19.1",
+        "@babel/types": "^7.19.0",
+        "@contrast/agent-lib": "^5.2.1",
+        "@contrast/distringuish": "^4.1.0",
+        "@contrast/require-hook": "^3.2.1"
+      },
+      "dependencies": {
+        "@contrast/agent-lib": {
+          "version": "5.3.5",
+          "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
+          "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@contrast/reporter": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@contrast/reporter/-/reporter-1.13.0.tgz",
+      "integrity": "sha512-TbY0Qyjkux7A3KKqYwOq6bt9IJcjp2FycldaV4c1BNpQHCkL4aB8ChlVmMhr4zxvcNidiKe4Bm7pvjnb11VDag==",
+      "dev": true,
+      "requires": {
+        "@contrast/common": "1.8.0",
+        "axios": "^0.27.2",
+        "crc-32": "^1.2.2",
+        "hpagent": "^1.2.0",
+        "safe-stable-stringify": "^2.4.1",
+        "sonic-boom": "^3.2.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        }
       }
     },
     "@contrast/require-hook": {
@@ -6123,10 +7324,39 @@
         "semver": "^7.5.3"
       }
     },
+    "@contrast/rewriter": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/rewriter/-/rewriter-1.4.0.tgz",
+      "integrity": "sha512-YBfJCdZuQlXHtZN9VS850mXcYZ4vw2e020uIkd2sH8QbvUZ9ipIWDFkBYSCT4eFHen/jtI+sJGzVMGym3sWyJw==",
+      "dev": true,
+      "requires": {
+        "@contrast/agent-swc-plugin": "^1.1.0",
+        "@contrast/agent-swc-plugin-unwrite": "^1.1.0",
+        "@contrast/synchronous-source-maps": "^1.1.3",
+        "@swc/core": "1.3.39",
+        "multi-stage-sourcemap": "^0.3.1"
+      }
+    },
+    "@contrast/route-coverage": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@contrast/route-coverage/-/route-coverage-1.4.0.tgz",
+      "integrity": "sha512-QxEbiGrncJ73159npqw+zYkcuNAX87yaRabtgwixhfO9ArEwMCWM4K0coLSZyt9uwY6AihmbRVbm2SlN7iqhcg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@contrast/common": "1.8.0"
+      }
+    },
+    "@contrast/scopes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/scopes/-/scopes-1.3.0.tgz",
+      "integrity": "sha512-TrXIawA69HoaHY46uPbgkqMe/F/5L2jhcIaRh75U8PCH6VhXt0J1QPa0pxEm9WzFRltrgbowLq8SYyR60IFuPA==",
+      "dev": true
+    },
     "@contrast/synchronous-source-maps": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/synchronous-source-maps/-/synchronous-source-maps-1.1.0.tgz",
-      "integrity": "sha512-oTJxcpgyFgmO/UTvpn4zeypnbhYpskI5VrR+mXIzV47BhRgRX5f9PNsevv+wfV41/SUVTPc3V0+kq0ZZRYVDkg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@contrast/synchronous-source-maps/-/synchronous-source-maps-1.1.5.tgz",
+      "integrity": "sha512-bi2ygCv6y60CzQ/kiGX4pEwViUTcC+mzWzPQCHwaso7Cm/VPHel027BUbOym/u3nD5VSd+wPrefplXqNZb9JYg==",
       "dev": true,
       "requires": {
         "source-map": "^0.7.3"
@@ -6335,6 +7565,53 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+          "dev": true
+        }
+      }
+    },
     "@napi-rs/triples": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.1.0.tgz",
@@ -6448,6 +7725,94 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@swc/core": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.39.tgz",
+      "integrity": "sha512-r5oIySPo2OkC14+gmhK5H1HnDEgOvj5kx6Ogxa+Og7KyWIHE8l1JjjW+4wzYdjxtdhRjVRhvoI6mPQNQz/btBg==",
+      "dev": true,
+      "requires": {
+        "@swc/core-darwin-arm64": "1.3.39",
+        "@swc/core-darwin-x64": "1.3.39",
+        "@swc/core-linux-arm-gnueabihf": "1.3.39",
+        "@swc/core-linux-arm64-gnu": "1.3.39",
+        "@swc/core-linux-arm64-musl": "1.3.39",
+        "@swc/core-linux-x64-gnu": "1.3.39",
+        "@swc/core-linux-x64-musl": "1.3.39",
+        "@swc/core-win32-arm64-msvc": "1.3.39",
+        "@swc/core-win32-ia32-msvc": "1.3.39",
+        "@swc/core-win32-x64-msvc": "1.3.39"
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.39.tgz",
+      "integrity": "sha512-qYR47BEfUvK1WRAP/LVbHakCo4mcksgDjRutJbkx3maTgHlSGYQKCQo7hz+or+n3cbR2abY0rFEgoCLjZctGOw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.39.tgz",
+      "integrity": "sha512-kqJ8OleY/y3S+HXnZxDWFVbKpRsb7gZDZr6Pksr8tzFba/6pLkZFBxds/zgfWIlUwri2Lcx0X872MJ46ghwv9w==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.39.tgz",
+      "integrity": "sha512-+c3A2BV0esPNHn/KKMqP+bphUF86sVKUIaxn5tKMDrnO8ckOpEMbJ+SwzYLtwC9JIYjWwryg/0yvWrdma26Irw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.39.tgz",
+      "integrity": "sha512-IRrfft7ANk3NR0qX6bXbfkqbT+WR0TMvgODQdZAtRQIt5ERFpdhcnYc4tlJzfV23R0Ek3kpdA8Gduj4tHk0K6w==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.39.tgz",
+      "integrity": "sha512-N8tnynqBdRzY8m2blPAnLUtaln0m8gb96q6ipnY+XoHQ3Z6uZoUq8jWAeFDhD+MCzM7qD2HyBDN7sEqiwMRO/g==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.39.tgz",
+      "integrity": "sha512-Jif56kWHOjQexCib4FVbGeUcBUc56cgNW7ELEKAUCID70z20JHMVTd5utcmfi1L9tywGMvfzqD5z+NQtrFV8GQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.39.tgz",
+      "integrity": "sha512-ZiGERr/mdsEwfSiWn2Qokd8a4TTJkLVta6Nan39Bozo6J789u4uDF9Cj5TWWMSanHYAK/oRDaUm1yo2/DSecAA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.39.tgz",
+      "integrity": "sha512-eUAk12LZ6RQHhe0ikZZsi0CPbRA6qsvoNQQ/6uwVF60CT0UnJrLiX3w3q30aXK3WjVR6uUlVEn7ze5t7HUeGyQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.39.tgz",
+      "integrity": "sha512-c3MIt+0gvZD0hmPOyoIJtdgx1ubP7E+uUnljw2+Nk8rO6qhIrWI08tWRNbT0HNLXHfHhKMJHvSAg3DGW8vG3Rg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.39.tgz",
+      "integrity": "sha512-c4xGToLavhHjrE0Um0GyXCilL3sKNRP71GgQTVvqTFHxMmdUCBdug28olMDE1gYsCqXHaF6rPtg3QmD6dhTzKQ==",
+      "dev": true,
+      "optional": true
     },
     "@types/long": {
       "version": "4.0.2",
@@ -6622,6 +7987,13 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async-hook-domain": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-3.0.2.tgz",
+      "integrity": "sha512-6nTkYKaKFtzR9mWv1kCGVpM4U2r30tQiuSbQuMMJyOCMKnPhg1JTYcJoPOR8RLsQgI/12NkE8FHi60gP3FzLBw==",
+      "dev": true,
+      "optional": true
+    },
     "async-hook-jl": {
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
@@ -6630,6 +8002,18 @@
       "requires": {
         "stack-chain": "^1.3.7"
       }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true
     },
     "axios": {
       "version": "0.25.0",
@@ -6938,6 +8322,15 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -7005,14 +8398,10 @@
       "dev": true
     },
     "crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-      "dev": true,
-      "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      }
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -7064,6 +8453,12 @@
         "strip-bom": "^4.0.0"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -7074,6 +8469,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "dev": true
     },
     "diff": {
@@ -7089,6 +8490,46 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "ee-first": {
@@ -7123,6 +8564,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -7332,12 +8782,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-      "dev": true
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -7392,6 +8836,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-redact": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
       "dev": true
     },
     "file-entry-cache": {
@@ -7484,6 +8934,17 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -7642,6 +9103,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
       "dev": true
     },
     "html-escaper": {
@@ -8534,6 +10001,12 @@
         }
       }
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -8668,6 +10141,52 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "dev": true,
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "dependencies": {
+        "sonic-boom": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+          "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        }
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+      "dev": true
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8722,12 +10241,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
-    "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-      "dev": true
-    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -8736,6 +10249,12 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
+    },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -8814,6 +10333,12 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8861,6 +10386,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "dev": true
     },
     "regexpp": {
       "version": "3.2.0",
@@ -8926,6 +10457,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true
     },
     "safer-buffer": {
@@ -9099,6 +10636,15 @@
         }
       }
     },
+    "sonic-boom": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "dev": true,
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9119,6 +10665,12 @@
         "which": "^2.0.1"
       }
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9135,6 +10687,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
     "string_decoder": {
@@ -9244,6 +10802,15 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "dev": true,
+      "requires": {
+        "real-require": "^0.1.0"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9335,6 +10902,12 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -9468,6 +11041,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "log-processor": "lib/log-processor/index.js"
       },
       "devDependencies": {
-        "@contrast/agent": "^4.19.2",
+        "@contrast/agent": "^4.32.13",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "eslint": "^7.32.0",
@@ -478,12 +478,11 @@
       }
     },
     "node_modules/@contrast/agent": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-4.19.2.tgz",
-      "integrity": "sha512-LrMZRHE7rrdsvM8xjZnsFSDX/L1MncxT0RJ8ed0AGBr4BaQWDgJpjH0K/PLI1ndu/Wkgc0aARq0OVQZmVUDbNA==",
+      "version": "4.32.13",
+      "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-4.32.13.tgz",
+      "integrity": "sha512-HOfd22CtcpYrviUH/T5bL25B3Ex6H07OxTG3ZqdDkmva7Z277tigoUghTfk0ZWrAd3H7tj8LWjh1UjBlNSo3Sg==",
       "bundleDependencies": [
         "winston",
-        "winston-syslog",
         "winston-daily-rotate-file"
       ],
       "dev": true,
@@ -493,13 +492,12 @@
         "@babel/template": "^7.10.4",
         "@babel/traverse": "^7.12.1",
         "@babel/types": "^7.12.1",
-        "@contrast/agent-lib": "^4.0.0",
-        "@contrast/distringuish-prebuilt": "^2.2.0",
+        "@contrast/agent-lib": "^4.3.0",
+        "@contrast/distringuish": "^4.2.1",
         "@contrast/flat": "^4.1.1",
-        "@contrast/fn-inspect": "^2.4.4",
-        "@contrast/heapdump": "^1.1.0",
-        "@contrast/protobuf-api": "^3.2.3",
-        "@contrast/require-hook": "^3.0.0",
+        "@contrast/fn-inspect": "^3.1.0",
+        "@contrast/protobuf-api": "^3.2.5",
+        "@contrast/require-hook": "^3.2.3",
         "@contrast/synchronous-source-maps": "^1.1.0",
         "amqp-connection-manager": "^3.2.2",
         "amqplib": "^0.8.0",
@@ -512,39 +510,40 @@
         "cookie": "^0.3.1",
         "crc-32": "^1.0.0",
         "fast-deep-equal": "^3.1.3",
-        "find-cache-dir": "^3.3.1",
+        "find-cache-dir": "^3.3.2",
         "getmac": "^5.20.0",
         "ipaddr.js": "^1.8.1",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify": "^1.0.1",
         "jspack": "0.0.4",
         "lodash": "^4.17.21",
-        "make-dir": "^3.1.0",
+        "make-dir": "^4.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "on-finished": "^2.3.0",
         "parent-package-json": "^2.0.1",
         "parseurl": "^1.3.3",
         "prom-client": "^12.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "uuid": "^8.3.2",
         "winston": "^3.7.2",
-        "winston-daily-rotate-file": "^3.5.1",
-        "winston-syslog": "*",
-        "yaml": "^1.10.0"
+        "winston-daily-rotate-file": "^4.7.1"
       },
       "bin": {
+        "config-diagnostics": "config-diagnostics.js",
         "contrast-transpile": "cli-rewriter.js",
         "node-contrast": "cli.js",
-        "perf-logs": "perf-logs.js"
+        "perf-logs": "perf-logs.js",
+        "system-diagnostics": "system-diagnostics.js"
       },
       "engines": {
-        "node": ">=12.13.0 <13 || >=14.15.0 <15 || >=16.9.1 <17",
+        "node": ">=12.13.0 <13 || >=14.15.0 <15 || >=16.9.1 <17 || >=18.7.0 <19",
         "npm": ">=6.13.7 <7 || >=7.11.0"
       }
     },
     "node_modules/@contrast/agent-lib": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-4.1.2.tgz",
-      "integrity": "sha512-7gWvmEapd1o1DpNiBMOLbhTfI2fy7E4LF0Cj/AisixTcpZlnBJSKyUpTigvW9QnxCcBqbx1oIGkJoPO/awgHXA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-4.3.0.tgz",
+      "integrity": "sha512-YKZ6wGdi/e89kw6KNOxUOTlOC/kI7lJm3t6pu422mseOy0dz7wJt1g/jHFlj4sAeUKJDNHKNeuN8KlxD+l6isg==",
       "dev": true,
       "dependencies": {
         "@node-rs/helper": "^1.2.1"
@@ -570,21 +569,17 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@contrast/agent/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "node_modules/@contrast/agent/node_modules/async": {
       "version": "3.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/bindings": {
-      "version": "1.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "node_modules/@contrast/agent/node_modules/color": {
       "version": "3.2.1",
@@ -621,15 +616,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/@contrast/agent/node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@contrast/agent/node_modules/colorspace": {
       "version": "1.1.4",
       "dev": true,
@@ -649,28 +635,8 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@contrast/agent/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/cycle": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/@contrast/agent/node_modules/enabled": {
       "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -682,34 +648,19 @@
       "license": "MIT"
     },
     "node_modules/@contrast/agent/node_modules/file-stream-rotator": {
-      "version": "0.4.1",
+      "version": "0.6.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "moment": "^2.11.2"
+        "moment": "^2.29.1"
       }
-    },
-    "node_modules/@contrast/agent/node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@contrast/agent/node_modules/fn.name": {
       "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/glossy": {
-      "version": "0.1.7",
-      "dev": true,
-      "inBundle": true,
-      "engines": {
-        "node": ">= 0.2.5"
-      }
     },
     "node_modules/@contrast/agent/node_modules/inherits": {
       "version": "2.0.4",
@@ -732,11 +683,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/@contrast/agent/node_modules/isarray": {
-      "version": "1.0.0",
+    "node_modules/@contrast/agent/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "inBundle": true,
-      "license": "MIT"
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/@contrast/agent/node_modules/kuler": {
       "version": "2.0.0",
@@ -757,8 +714,23 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/@contrast/agent/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@contrast/agent/node_modules/moment": {
-      "version": "2.29.2",
+      "version": "2.29.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -772,20 +744,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/@contrast/agent/node_modules/nan": {
-      "version": "2.14.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@contrast/agent/node_modules/object-hash": {
-      "version": "1.3.1",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 6"
       }
     },
     "node_modules/@contrast/agent/node_modules/one-time": {
@@ -795,27 +760,6 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
-      }
-    },
-    "node_modules/@contrast/agent/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/@contrast/agent/node_modules/safe-buffer": {
@@ -872,21 +816,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/@contrast/agent/node_modules/unix-dgram": {
-      "version": "2.0.4",
-      "dev": true,
-      "hasInstallScript": true,
-      "inBundle": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.3.0",
-        "nan": "^2.13.2"
-      },
-      "engines": {
-        "node": ">=0.10.48"
-      }
-    },
     "node_modules/@contrast/agent/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
@@ -923,98 +852,50 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@contrast/agent/node_modules/winston-compat": {
-      "version": "0.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cycle": "~1.0.3",
-        "logform": "^1.6.0",
-        "triple-beam": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 6.4.0"
-      }
-    },
-    "node_modules/@contrast/agent/node_modules/winston-compat/node_modules/fecha": {
-      "version": "2.3.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/@contrast/agent/node_modules/winston-compat/node_modules/logform": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "colors": "^1.2.1",
-        "fast-safe-stringify": "^2.0.4",
-        "fecha": "^2.3.3",
-        "ms": "^2.1.1",
-        "triple-beam": "^1.2.0"
-      }
-    },
     "node_modules/@contrast/agent/node_modules/winston-daily-rotate-file": {
-      "version": "3.10.0",
+      "version": "4.7.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "file-stream-rotator": "^0.4.1",
-        "object-hash": "^1.3.0",
-        "semver": "^6.2.0",
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^2.0.1",
         "triple-beam": "^1.3.0",
-        "winston-compat": "^0.1.4",
-        "winston-transport": "^4.2.0"
+        "winston-transport": "^4.4.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       },
       "peerDependencies": {
-        "winston": "^2 || ^3"
-      }
-    },
-    "node_modules/@contrast/agent/node_modules/winston-daily-rotate-file/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@contrast/agent/node_modules/winston-syslog": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cycle": "^1.0.3",
-        "glossy": "^0.1.7"
-      },
-      "engines": {
-        "node": ">= 4.2.2"
-      },
-      "optionalDependencies": {
-        "unix-dgram": "^2.0.2"
-      },
-      "peerDependencies": {
-        "winston": "^3.0.0"
+        "winston": "^3"
       }
     },
     "node_modules/@contrast/agent/node_modules/winston-transport": {
-      "version": "4.4.0",
+      "version": "4.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "^2.3.7",
-        "triple-beam": "^1.2.0"
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
       },
       "engines": {
         "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/@contrast/agent/node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@contrast/agent/node_modules/winston/node_modules/readable-stream": {
@@ -1045,24 +926,19 @@
         "node": ">= 6.4.0"
       }
     },
-    "node_modules/@contrast/distringuish-prebuilt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/distringuish-prebuilt/-/distringuish-prebuilt-2.2.1.tgz",
-      "integrity": "sha512-y5U6RJhpC9ulbfVAhjfFLoPMm+BxI/sSowAkgG3T/MvCs3VPHXwJ+Ab0Skp5xONr5/K5l9a/F5r6AMxjuEuEqw==",
+    "node_modules/@contrast/distringuish": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/distringuish/-/distringuish-4.3.0.tgz",
+      "integrity": "sha512-HWDYdKhx3lHd9d4US2nSstaH3clDBNRtvFLOQnjNCbNMHDflrUQ44zfIDdp2n2w/3L3g6wHb6Cti8IRZMQEsUw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "@octokit/rest": "^18.3.3",
-        "semver": "^6.3.0",
-        "xml-js": "^1.6.11"
-      }
-    },
-    "node_modules/@contrast/distringuish-prebuilt/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "nan": "^2.17.0",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@contrast/flat": {
@@ -1072,34 +948,23 @@
       "dev": true
     },
     "node_modules/@contrast/fn-inspect": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-2.4.7.tgz",
-      "integrity": "sha512-q/UUvcUDpSYhtwJacOIx1S4d8/eZBG4CvNhvlfPDkDO+5nnWwPTONEmKlN22LYHnFWrTBONBFvjCPbz6uUmRPQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.1.tgz",
+      "integrity": "sha512-BqsC5YslFxX/jgUzjAFEqnI0ngXXmUAFHUrhLSJu7lFYwTB7U1bLCUcjsZVnaO2bh0QDrmGAL/W0pe1Eu7PIIQ==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
-        "@octokit/rest": "^18.3.5",
-        "xml-js": "^1.6.11"
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
       },
       "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@contrast/heapdump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/heapdump/-/heapdump-1.1.0.tgz",
-      "integrity": "sha512-A5jxxYLjIPvdcyJ0tCJp8x61ZAXMiYWDpl0z61eOVGY1ef0Gv963uqQjw4SYSUtXoxORh3/Hg15GFgMmQPrqYA==",
-      "dev": true,
-      "dependencies": {
-        "nan": "^2.15.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@contrast/protobuf-api": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.3.tgz",
-      "integrity": "sha512-PdZRijX4VZ8xHfGNHu+HPqFGoS7Ucn/BQ/xdbhN3cGTf4OX+aSotdr6inRoAlDF8jS8ZOV3ZIqsyM7qYqD8Eig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.6.tgz",
+      "integrity": "sha512-BteZ6lxZCZUU9g67+vbjG5GkJGZn7Zr38jUASLfKVeX9DucMoFWY9llb4H5pE2RTx9LMvRhTiUqnytxbVfJVZw==",
       "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.5.3",
@@ -1107,13 +972,13 @@
       }
     },
     "node_modules/@contrast/require-hook": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/require-hook/-/require-hook-3.1.0.tgz",
-      "integrity": "sha512-68miFw7HdVRw4i9QO14ILnl4jISXEcqOy0+8JvVSHvasxq2+gyY7Mj3wuEve+CToqaafEWSle6pJjsV/LXOhvg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@contrast/require-hook/-/require-hook-3.2.3.tgz",
+      "integrity": "sha512-P/7WxFJOsruF5YFBnweAj5RInyhHVlxMfFYPOeJRHeSiRaiHShw5ZDi9TahhMUTGusb1UZMnML8RmsZVAUag0A==",
       "dev": true,
       "dependencies": {
         "parent-package-json": "^2.0.1",
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -1181,12 +1046,12 @@
       "dev": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
-      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "dev": true,
       "dependencies": {
-        "@grpc/proto-loader": "^0.6.4",
+        "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -1194,22 +1059,63 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
+      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
       "dev": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.2.0"
+        "protobufjs": "^7.0.0",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1365,138 +1271,6 @@
         "@napi-rs/triples": "^1.1.0"
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^6.0.3",
-        "is-plain-object": "^5.0.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/request": "^5.6.0",
-        "@octokit/types": "^6.0.3",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
-      "dev": true
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^6.34.0"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=2"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^6.34.0",
-        "deprecation": "^2.3.1"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.1.0",
-        "@octokit/types": "^6.16.1",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^6.0.3",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.8",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^11.2.0"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1603,9 +1377,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -1749,9 +1523,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1858,12 +1632,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/before-after-hook": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
     "node_modules/big-integer": {
@@ -2425,12 +2193,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true
-    },
     "node_modules/destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -2881,9 +2643,9 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -3143,9 +2905,9 @@
       }
     },
     "node_modules/google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
       "dev": true
     },
     "node_modules/graceful-fs": {
@@ -3366,15 +3128,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -3710,7 +3463,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
     "node_modules/lodash.clonedeep": {
@@ -4030,9 +3783,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "dev": true
     },
     "node_modules/nanoid": {
@@ -4084,6 +3837,12 @@
         "isarray": "0.0.1"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -4102,6 +3861,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-preload": {
@@ -4663,9 +4433,9 @@
       "dev": true
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4679,14 +4449,18 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4882,16 +4656,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5144,26 +4912,26 @@
       "dev": true
     },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -5361,12 +5129,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5549,18 +5311,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
-      "dependencies": {
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "xml-js": "bin/cli.js"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5575,15 +5325,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -5985,9 +5726,9 @@
       }
     },
     "@contrast/agent": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-4.19.2.tgz",
-      "integrity": "sha512-LrMZRHE7rrdsvM8xjZnsFSDX/L1MncxT0RJ8ed0AGBr4BaQWDgJpjH0K/PLI1ndu/Wkgc0aARq0OVQZmVUDbNA==",
+      "version": "4.32.13",
+      "resolved": "https://registry.npmjs.org/@contrast/agent/-/agent-4.32.13.tgz",
+      "integrity": "sha512-HOfd22CtcpYrviUH/T5bL25B3Ex6H07OxTG3ZqdDkmva7Z277tigoUghTfk0ZWrAd3H7tj8LWjh1UjBlNSo3Sg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.12.1",
@@ -5995,13 +5736,12 @@
         "@babel/template": "^7.10.4",
         "@babel/traverse": "^7.12.1",
         "@babel/types": "^7.12.1",
-        "@contrast/agent-lib": "^4.0.0",
-        "@contrast/distringuish-prebuilt": "^2.2.0",
+        "@contrast/agent-lib": "^4.3.0",
+        "@contrast/distringuish": "^4.2.1",
         "@contrast/flat": "^4.1.1",
-        "@contrast/fn-inspect": "^2.4.4",
-        "@contrast/heapdump": "^1.1.0",
-        "@contrast/protobuf-api": "^3.2.3",
-        "@contrast/require-hook": "^3.0.0",
+        "@contrast/fn-inspect": "^3.1.0",
+        "@contrast/protobuf-api": "^3.2.5",
+        "@contrast/require-hook": "^3.2.3",
         "@contrast/synchronous-source-maps": "^1.1.0",
         "amqp-connection-manager": "^3.2.2",
         "amqplib": "^0.8.0",
@@ -6014,24 +5754,23 @@
         "cookie": "^0.3.1",
         "crc-32": "^1.0.0",
         "fast-deep-equal": "^3.1.3",
-        "find-cache-dir": "^3.3.1",
+        "find-cache-dir": "^3.3.2",
         "getmac": "^5.20.0",
         "ipaddr.js": "^1.8.1",
+        "js-yaml": "^4.1.0",
         "json-stable-stringify": "^1.0.1",
         "jspack": "0.0.4",
         "lodash": "^4.17.21",
-        "make-dir": "^3.1.0",
+        "make-dir": "^4.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "on-finished": "^2.3.0",
         "parent-package-json": "^2.0.1",
         "parseurl": "^1.3.3",
         "prom-client": "^12.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "uuid": "^8.3.2",
         "winston": "^3.7.2",
-        "winston-daily-rotate-file": "^3.5.1",
-        "winston-syslog": "*",
-        "yaml": "^1.10.0"
+        "winston-daily-rotate-file": "^4.7.1"
       },
       "dependencies": {
         "@colors/colors": {
@@ -6049,19 +5788,16 @@
             "kuler": "^2.0.0"
           }
         },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
         "async": {
           "version": "3.2.3",
           "bundled": true,
           "dev": true
-        },
-        "bindings": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "file-uri-to-path": "1.0.0"
-          }
         },
         "color": {
           "version": "3.2.1",
@@ -6094,11 +5830,6 @@
             "simple-swizzle": "^0.2.2"
           }
         },
-        "colors": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true
-        },
         "colorspace": {
           "version": "1.1.4",
           "bundled": true,
@@ -6114,23 +5845,8 @@
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
           "dev": true
         },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cycle": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
         "enabled": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-safe-stringify": {
-          "version": "2.0.7",
           "bundled": true,
           "dev": true
         },
@@ -6140,26 +5856,15 @@
           "dev": true
         },
         "file-stream-rotator": {
-          "version": "0.4.1",
+          "version": "0.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "moment": "^2.11.2"
+            "moment": "^2.29.1"
           }
-        },
-        "file-uri-to-path": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "fn.name": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "glossy": {
-          "version": "0.1.7",
           "bundled": true,
           "dev": true
         },
@@ -6178,10 +5883,14 @@
           "bundled": true,
           "dev": true
         },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         },
         "kuler": {
           "version": "2.0.0",
@@ -6200,8 +5909,17 @@
             "triple-beam": "^1.3.0"
           }
         },
+        "make-dir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+          "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.5.3"
+          }
+        },
         "moment": {
-          "version": "2.29.2",
+          "version": "2.29.4",
           "bundled": true,
           "dev": true
         },
@@ -6210,14 +5928,8 @@
           "bundled": true,
           "dev": true
         },
-        "nan": {
-          "version": "2.14.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
         "object-hash": {
-          "version": "1.3.1",
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -6227,25 +5939,6 @@
           "dev": true,
           "requires": {
             "fn.name": "1.x.x"
-          }
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
           }
         },
         "safe-buffer": {
@@ -6288,16 +5981,6 @@
           "version": "1.3.0",
           "bundled": true,
           "dev": true
-        },
-        "unix-dgram": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.3.0",
-            "nan": "^2.13.2"
-          }
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -6349,102 +6032,59 @@
             }
           }
         },
-        "winston-compat": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cycle": "~1.0.3",
-            "logform": "^1.6.0",
-            "triple-beam": "^1.2.0"
-          },
-          "dependencies": {
-            "fecha": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true
-            },
-            "logform": {
-              "version": "1.10.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "colors": "^1.2.1",
-                "fast-safe-stringify": "^2.0.4",
-                "fecha": "^2.3.3",
-                "ms": "^2.1.1",
-                "triple-beam": "^1.2.0"
-              }
-            }
-          }
-        },
         "winston-daily-rotate-file": {
-          "version": "3.10.0",
+          "version": "4.7.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "file-stream-rotator": "^0.4.1",
-            "object-hash": "^1.3.0",
-            "semver": "^6.2.0",
+            "file-stream-rotator": "^0.6.1",
+            "object-hash": "^2.0.1",
             "triple-beam": "^1.3.0",
-            "winston-compat": "^0.1.4",
-            "winston-transport": "^4.2.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "winston-syslog": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cycle": "^1.0.3",
-            "glossy": "^0.1.7",
-            "unix-dgram": "^2.0.2"
+            "winston-transport": "^4.4.0"
           }
         },
         "winston-transport": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "^2.3.7",
-            "triple-beam": "^1.2.0"
+            "logform": "^2.3.2",
+            "readable-stream": "^3.6.0",
+            "triple-beam": "^1.3.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
           }
         }
       }
     },
     "@contrast/agent-lib": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-4.1.2.tgz",
-      "integrity": "sha512-7gWvmEapd1o1DpNiBMOLbhTfI2fy7E4LF0Cj/AisixTcpZlnBJSKyUpTigvW9QnxCcBqbx1oIGkJoPO/awgHXA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-4.3.0.tgz",
+      "integrity": "sha512-YKZ6wGdi/e89kw6KNOxUOTlOC/kI7lJm3t6pu422mseOy0dz7wJt1g/jHFlj4sAeUKJDNHKNeuN8KlxD+l6isg==",
       "dev": true,
       "requires": {
         "@node-rs/helper": "^1.2.1"
       }
     },
-    "@contrast/distringuish-prebuilt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/distringuish-prebuilt/-/distringuish-prebuilt-2.2.1.tgz",
-      "integrity": "sha512-y5U6RJhpC9ulbfVAhjfFLoPMm+BxI/sSowAkgG3T/MvCs3VPHXwJ+Ab0Skp5xONr5/K5l9a/F5r6AMxjuEuEqw==",
+    "@contrast/distringuish": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@contrast/distringuish/-/distringuish-4.3.0.tgz",
+      "integrity": "sha512-HWDYdKhx3lHd9d4US2nSstaH3clDBNRtvFLOQnjNCbNMHDflrUQ44zfIDdp2n2w/3L3g6wHb6Cti8IRZMQEsUw==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^18.3.3",
-        "semver": "^6.3.0",
-        "xml-js": "^1.6.11"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
+        "nan": "^2.17.0",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build": "^4.5.0"
       }
     },
     "@contrast/flat": {
@@ -6454,28 +6094,19 @@
       "dev": true
     },
     "@contrast/fn-inspect": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-2.4.7.tgz",
-      "integrity": "sha512-q/UUvcUDpSYhtwJacOIx1S4d8/eZBG4CvNhvlfPDkDO+5nnWwPTONEmKlN22LYHnFWrTBONBFvjCPbz6uUmRPQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/fn-inspect/-/fn-inspect-3.3.1.tgz",
+      "integrity": "sha512-BqsC5YslFxX/jgUzjAFEqnI0ngXXmUAFHUrhLSJu7lFYwTB7U1bLCUcjsZVnaO2bh0QDrmGAL/W0pe1Eu7PIIQ==",
       "dev": true,
       "requires": {
-        "@octokit/rest": "^18.3.5",
-        "xml-js": "^1.6.11"
-      }
-    },
-    "@contrast/heapdump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/heapdump/-/heapdump-1.1.0.tgz",
-      "integrity": "sha512-A5jxxYLjIPvdcyJ0tCJp8x61ZAXMiYWDpl0z61eOVGY1ef0Gv963uqQjw4SYSUtXoxORh3/Hg15GFgMmQPrqYA==",
-      "dev": true,
-      "requires": {
-        "nan": "^2.15.0"
+        "nan": "^2.16.0",
+        "node-gyp-build": "^4.4.0"
       }
     },
     "@contrast/protobuf-api": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.3.tgz",
-      "integrity": "sha512-PdZRijX4VZ8xHfGNHu+HPqFGoS7Ucn/BQ/xdbhN3cGTf4OX+aSotdr6inRoAlDF8jS8ZOV3ZIqsyM7qYqD8Eig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@contrast/protobuf-api/-/protobuf-api-3.2.6.tgz",
+      "integrity": "sha512-BteZ6lxZCZUU9g67+vbjG5GkJGZn7Zr38jUASLfKVeX9DucMoFWY9llb4H5pE2RTx9LMvRhTiUqnytxbVfJVZw==",
       "dev": true,
       "requires": {
         "@grpc/grpc-js": "^1.5.3",
@@ -6483,13 +6114,13 @@
       }
     },
     "@contrast/require-hook": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@contrast/require-hook/-/require-hook-3.1.0.tgz",
-      "integrity": "sha512-68miFw7HdVRw4i9QO14ILnl4jISXEcqOy0+8JvVSHvasxq2+gyY7Mj3wuEve+CToqaafEWSle6pJjsV/LXOhvg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@contrast/require-hook/-/require-hook-3.2.3.tgz",
+      "integrity": "sha512-P/7WxFJOsruF5YFBnweAj5RInyhHVlxMfFYPOeJRHeSiRaiHShw5ZDi9TahhMUTGusb1UZMnML8RmsZVAUag0A==",
       "dev": true,
       "requires": {
         "parent-package-json": "^2.0.1",
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       }
     },
     "@contrast/synchronous-source-maps": {
@@ -6544,26 +6175,60 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
-      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "dev": true,
       "requires": {
-        "@grpc/proto-loader": "^0.6.4",
+        "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.12.tgz",
-      "integrity": "sha512-filTVbETFnxb9CyRX98zN18ilChTuf/C5scZ2xyaOTp0EHGq0/ufX8rjqXUcSb1Gpv7eZq4M2jDvbh9BogKnrg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
+      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
       "dev": true,
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.10.0",
-        "yargs": "^16.2.0"
+        "protobufjs": "^7.0.0",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -6685,130 +6350,6 @@
         "@napi-rs/triples": "^1.1.0"
       }
     },
-    "@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-      "dev": true,
-      "requires": {
-        "@octokit/types": "^6.0.3"
-      }
-    },
-    "@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-      "dev": true,
-      "requires": {
-        "@octokit/auth-token": "^2.4.4",
-        "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
-        "@octokit/request-error": "^2.0.5",
-        "@octokit/types": "^6.0.3",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "@octokit/endpoint": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
-      "dev": true,
-      "requires": {
-        "@octokit/types": "^6.0.3",
-        "is-plain-object": "^5.0.0",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "@octokit/graphql": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
-      "dev": true,
-      "requires": {
-        "@octokit/request": "^5.6.0",
-        "@octokit/types": "^6.0.3",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "@octokit/openapi-types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
-      "dev": true
-    },
-    "@octokit/plugin-paginate-rest": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
-      "dev": true,
-      "requires": {
-        "@octokit/types": "^6.34.0"
-      }
-    },
-    "@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
-    },
-    "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
-      "dev": true,
-      "requires": {
-        "@octokit/types": "^6.34.0",
-        "deprecation": "^2.3.1"
-      }
-    },
-    "@octokit/request": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-      "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
-      "dev": true,
-      "requires": {
-        "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.1.0",
-        "@octokit/types": "^6.16.1",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "universal-user-agent": "^6.0.0"
-      }
-    },
-    "@octokit/request-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-      "dev": true,
-      "requires": {
-        "@octokit/types": "^6.0.3",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      }
-    },
-    "@octokit/rest": {
-      "version": "18.12.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
-      "dev": true,
-      "requires": {
-        "@octokit/core": "^3.5.1",
-        "@octokit/plugin-paginate-rest": "^2.16.8",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
-      }
-    },
-    "@octokit/types": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
-      "dev": true,
-      "requires": {
-        "@octokit/openapi-types": "^11.2.0"
-      }
-    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -6915,9 +6456,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -7015,9 +6556,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -7103,12 +6644,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "before-after-hook": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
     },
     "big-integer": {
@@ -7535,12 +7070,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
-    "deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true
-    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -7899,9 +7428,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -8068,9 +7597,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
       "dev": true
     },
     "graceful-fs": {
@@ -8233,12 +7762,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
-    },
-    "is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true
     },
     "is-stream": {
@@ -8497,7 +8020,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -8749,9 +8272,9 @@
       }
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
       "dev": true
     },
     "nanoid": {
@@ -8796,6 +8319,12 @@
         }
       }
     },
+    "node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -8804,6 +8333,12 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "dev": true
     },
     "node-preload": {
       "version": "0.2.1",
@@ -9224,9 +8759,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -9239,9 +8774,16 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+          "dev": true
+        }
       }
     },
     "proxy-addr": {
@@ -9392,16 +8934,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -9608,23 +9144,23 @@
       "dev": true
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -9775,12 +9311,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9928,15 +9458,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
-      "requires": {
-        "sax": "^1.2.4"
-      }
-    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9947,12 +9468,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@contrast/agent": "^4.32.13",
         "@contrast/protect-agent": "^5.7.0",
-        "@contrast/rasp-v3": "^0.5.0",
+        "@contrast/rasp-v3": "^0.7.0-alpha.2",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "eslint": "^7.32.0",
@@ -1092,6 +1092,18 @@
         "npm": ">=6.13.7 <7 || >= 8.3.1"
       }
     },
+    "node_modules/@contrast/fireball": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fireball/-/fireball-0.5.0.tgz",
+      "integrity": "sha512-CSvxVw6v5C9W/0MbQ8G8Ql8S+ft58S47rowcWqql5RhZSBYWstoeQxp6WhCRekpTm4XdtRNxjb//n3EAz9Op3Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@contrast/flat": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contrast/flat/-/flat-4.2.0.tgz",
@@ -1294,9 +1306,9 @@
       }
     },
     "node_modules/@contrast/rasp-v3": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.5.0.tgz",
-      "integrity": "sha512-nkxfl6AEqJcYTjpOltDkifyzlze7DC/Onyf2mNuN1wwEOClwb8b0Oa0R9/VY+6LpdE5SSzkLGpc+fPKVYj46Rw==",
+      "version": "0.7.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.7.0-alpha.2.tgz",
+      "integrity": "sha512-FEVK2aluvi+FLvTmRmIsE8Srh8Iha/UkTN/ul+Du8XkSWg/kpOP/3YhVZ6TJiYQPk8Lv64S/AYDFMrzd/QgYsg==",
       "dev": true,
       "dependencies": {
         "@babel/generator": "^7.19.0",
@@ -1304,18 +1316,156 @@
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.19.1",
         "@babel/types": "^7.19.0",
-        "@contrast/agent-lib": "^5.2.1",
-        "@contrast/distringuish": "^4.1.0",
-        "@contrast/require-hook": "^3.2.1"
+        "@contrast/agent-lib": "^8.1.0",
+        "@contrast/distringuish": "^4.3.0",
+        "@contrast/fireball": "^0.5.0",
+        "@contrast/instrumentation": "1.1.1",
+        "@contrast/require-hook": "^3.2.1",
+        "@contrast/scopes": "^1.2.0",
+        "@contrast/stash": "^4.2.2",
+        "@contrast/synchronous-source-maps": "^1.1.5",
+        "async-hook-domain": "^3.0.2",
+        "multi-stage-sourcemap": "^0.3.1",
+        "parent-package-json": "^2.0.1",
+        "pino": "^8.11.0",
+        "rotating-file-stream": "^3.1.0",
+        "source-map": "^0.7.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 16.14.1",
+        "npm": ">= 8.5.0"
       }
     },
     "node_modules/@contrast/rasp-v3/node_modules/@contrast/agent-lib": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
-      "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-8.1.0.tgz",
+      "integrity": "sha512-9qXwPxE5An1RWISf5//Nk/bxA1GC09qU0VYNOnrMaBRigu5c9I8zRVUNdfXdE5nIRD3Lxu/PZw6E9nE5FCLUmQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.1"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
+      "dev": true
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/pino": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
+      "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+      "dev": true
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@contrast/rasp-v3/node_modules/thread-stream": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+      "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+      "dev": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/@contrast/reporter": {
@@ -1398,6 +1548,20 @@
       "engines": {
         "node": ">= 14.15.0",
         "npm": ">=6.13.7 <7 || >= 8.3.1"
+      }
+    },
+    "node_modules/@contrast/stash": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@contrast/stash/-/stash-4.2.2.tgz",
+      "integrity": "sha512-Y1rnRhgbqUm59bVUR2MLw3Md3Hg3LHWTUt/9iN8xA8uPBVYWg5JlZ8OfkYOGUCOVhztHKxYIKvE8HKWqdDu7TA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
       }
     },
     "node_modules/@contrast/synchronous-source-maps": {
@@ -1741,6 +1905,15 @@
         "@napi-rs/triples": "^1.1.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1866,86 +2039,6 @@
         "@swc/core-win32-x64-msvc": "1.3.39"
       }
     },
-    "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.39.tgz",
-      "integrity": "sha512-qYR47BEfUvK1WRAP/LVbHakCo4mcksgDjRutJbkx3maTgHlSGYQKCQo7hz+or+n3cbR2abY0rFEgoCLjZctGOw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.39.tgz",
-      "integrity": "sha512-kqJ8OleY/y3S+HXnZxDWFVbKpRsb7gZDZr6Pksr8tzFba/6pLkZFBxds/zgfWIlUwri2Lcx0X872MJ46ghwv9w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.39.tgz",
-      "integrity": "sha512-+c3A2BV0esPNHn/KKMqP+bphUF86sVKUIaxn5tKMDrnO8ckOpEMbJ+SwzYLtwC9JIYjWwryg/0yvWrdma26Irw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.39.tgz",
-      "integrity": "sha512-IRrfft7ANk3NR0qX6bXbfkqbT+WR0TMvgODQdZAtRQIt5ERFpdhcnYc4tlJzfV23R0Ek3kpdA8Gduj4tHk0K6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.39.tgz",
-      "integrity": "sha512-N8tnynqBdRzY8m2blPAnLUtaln0m8gb96q6ipnY+XoHQ3Z6uZoUq8jWAeFDhD+MCzM7qD2HyBDN7sEqiwMRO/g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.3.39",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.39.tgz",
@@ -1978,54 +2071,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.39.tgz",
-      "integrity": "sha512-eUAk12LZ6RQHhe0ikZZsi0CPbRA6qsvoNQQ/6uwVF60CT0UnJrLiX3w3q30aXK3WjVR6uUlVEn7ze5t7HUeGyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.39.tgz",
-      "integrity": "sha512-c3MIt+0gvZD0hmPOyoIJtdgx1ubP7E+uUnljw2+Nk8rO6qhIrWI08tWRNbT0HNLXHfHhKMJHvSAg3DGW8vG3Rg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.39.tgz",
-      "integrity": "sha512-c4xGToLavhHjrE0Um0GyXCilL3sKNRP71GgQTVvqTFHxMmdUCBdug28olMDE1gYsCqXHaF6rPtg3QmD6dhTzKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -2043,6 +2088,18 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -2268,7 +2325,6 @@
       "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-3.0.2.tgz",
       "integrity": "sha512-6nTkYKaKFtzR9mWv1kCGVpM4U2r30tQiuSbQuMMJyOCMKnPhg1JTYcJoPOR8RLsQgI/12NkE8FHi60gP3FzLBw==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=16"
       }
@@ -2314,6 +2370,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/big-integer": {
       "version": "1.6.50",
@@ -2429,6 +2505,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-more-ints": {
@@ -3303,6 +3403,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -3565,20 +3683,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3795,6 +3899,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -5228,6 +5352,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -5488,6 +5621,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rotating-file-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.1.1.tgz",
+      "integrity": "sha512-PNF1iDkxcZG+T87uUzLlcO4aquTCyY8yl+Q/OTK4dMwhwWDYWU4ZATYeIXHmYVGIzqZ2MrpY4WIkYc9Bsc3Nzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "url": "https://www.blockchain.com/btc/address/12p1p5q7sK75tPyuesZmssiMYr4TKzpSCN"
       }
     },
     "node_modules/run-script-os": {
@@ -5970,6 +6115,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -7110,6 +7261,15 @@
         "parent-package-json": "^2.0.1"
       }
     },
+    "@contrast/fireball": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@contrast/fireball/-/fireball-0.5.0.tgz",
+      "integrity": "sha512-CSvxVw6v5C9W/0MbQ8G8Ql8S+ft58S47rowcWqql5RhZSBYWstoeQxp6WhCRekpTm4XdtRNxjb//n3EAz9Op3Q==",
+      "dev": true,
+      "requires": {
+        "@opentelemetry/api": "^1.2.0"
+      }
+    },
     "@contrast/flat": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contrast/flat/-/flat-4.2.0.tgz",
@@ -7262,9 +7422,9 @@
       }
     },
     "@contrast/rasp-v3": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.5.0.tgz",
-      "integrity": "sha512-nkxfl6AEqJcYTjpOltDkifyzlze7DC/Onyf2mNuN1wwEOClwb8b0Oa0R9/VY+6LpdE5SSzkLGpc+fPKVYj46Rw==",
+      "version": "0.7.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@contrast/rasp-v3/-/rasp-v3-0.7.0-alpha.2.tgz",
+      "integrity": "sha512-FEVK2aluvi+FLvTmRmIsE8Srh8Iha/UkTN/ul+Du8XkSWg/kpOP/3YhVZ6TJiYQPk8Lv64S/AYDFMrzd/QgYsg==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.19.0",
@@ -7272,18 +7432,126 @@
         "@babel/template": "^7.18.10",
         "@babel/traverse": "^7.19.1",
         "@babel/types": "^7.19.0",
-        "@contrast/agent-lib": "^5.2.1",
-        "@contrast/distringuish": "^4.1.0",
-        "@contrast/require-hook": "^3.2.1"
+        "@contrast/agent-lib": "^8.1.0",
+        "@contrast/distringuish": "^4.3.0",
+        "@contrast/fireball": "^0.5.0",
+        "@contrast/instrumentation": "1.1.1",
+        "@contrast/require-hook": "^3.2.1",
+        "@contrast/scopes": "^1.2.0",
+        "@contrast/stash": "^4.2.2",
+        "@contrast/synchronous-source-maps": "^1.1.5",
+        "async-hook-domain": "^3.0.2",
+        "multi-stage-sourcemap": "^0.3.1",
+        "parent-package-json": "^2.0.1",
+        "pino": "^8.11.0",
+        "rotating-file-stream": "^3.1.0",
+        "source-map": "^0.7.4",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@contrast/agent-lib": {
-          "version": "5.3.5",
-          "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-5.3.5.tgz",
-          "integrity": "sha512-U3CJUDnsoj9Oo97ZqnXakzegZSfSzRvnjcRE/u3VR6VTbP/tTpOlEIWtu/uvf5kvzPwBsjHrvq/r75ysUKVNWQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/@contrast/agent-lib/-/agent-lib-8.1.0.tgz",
+          "integrity": "sha512-9qXwPxE5An1RWISf5//Nk/bxA1GC09qU0VYNOnrMaBRigu5c9I8zRVUNdfXdE5nIRD3Lxu/PZw6E9nE5FCLUmQ==",
           "dev": true,
           "requires": {
             "detect-libc": "^2.0.1"
+          }
+        },
+        "on-exit-leak-free": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+          "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
+          "dev": true
+        },
+        "pino": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.2.tgz",
+          "integrity": "sha512-zKu9aWeSWTy1JgvxIpZveJKKsAr4+6uNMZ0Vf0KRwzl/UNZA3XjHiIl/0WwqLMkDwuHuDkT5xAgPA2jpKq4whA==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "fast-redact": "^3.1.1",
+            "on-exit-leak-free": "^2.1.0",
+            "pino-abstract-transport": "v1.0.0",
+            "pino-std-serializers": "^6.0.0",
+            "process-warning": "^2.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "real-require": "^0.2.0",
+            "safe-stable-stringify": "^2.3.1",
+            "sonic-boom": "^3.1.0",
+            "thread-stream": "^2.0.0"
+          }
+        },
+        "pino-abstract-transport": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+          "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^4.0.0",
+            "split2": "^4.0.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+          "dev": true
+        },
+        "process-warning": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+          "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "real-require": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "thread-stream": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+          "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+          "dev": true,
+          "requires": {
+            "real-require": "^0.2.0"
           }
         }
       }
@@ -7352,6 +7620,16 @@
       "resolved": "https://registry.npmjs.org/@contrast/scopes/-/scopes-1.3.0.tgz",
       "integrity": "sha512-TrXIawA69HoaHY46uPbgkqMe/F/5L2jhcIaRh75U8PCH6VhXt0J1QPa0pxEm9WzFRltrgbowLq8SYyR60IFuPA==",
       "dev": true
+    },
+    "@contrast/stash": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@contrast/stash/-/stash-4.2.2.tgz",
+      "integrity": "sha512-Y1rnRhgbqUm59bVUR2MLw3Md3Hg3LHWTUt/9iN8xA8uPBVYWg5JlZ8OfkYOGUCOVhztHKxYIKvE8HKWqdDu7TA==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build": "^4.5.0"
+      }
     },
     "@contrast/synchronous-source-maps": {
       "version": "1.1.5",
@@ -7627,6 +7905,12 @@
         "@napi-rs/triples": "^1.1.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "dev": true
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -7744,41 +8028,6 @@
         "@swc/core-win32-x64-msvc": "1.3.39"
       }
     },
-    "@swc/core-darwin-arm64": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.39.tgz",
-      "integrity": "sha512-qYR47BEfUvK1WRAP/LVbHakCo4mcksgDjRutJbkx3maTgHlSGYQKCQo7hz+or+n3cbR2abY0rFEgoCLjZctGOw==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-darwin-x64": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.39.tgz",
-      "integrity": "sha512-kqJ8OleY/y3S+HXnZxDWFVbKpRsb7gZDZr6Pksr8tzFba/6pLkZFBxds/zgfWIlUwri2Lcx0X872MJ46ghwv9w==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.39.tgz",
-      "integrity": "sha512-+c3A2BV0esPNHn/KKMqP+bphUF86sVKUIaxn5tKMDrnO8ckOpEMbJ+SwzYLtwC9JIYjWwryg/0yvWrdma26Irw==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.39.tgz",
-      "integrity": "sha512-IRrfft7ANk3NR0qX6bXbfkqbT+WR0TMvgODQdZAtRQIt5ERFpdhcnYc4tlJzfV23R0Ek3kpdA8Gduj4tHk0K6w==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-linux-arm64-musl": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.39.tgz",
-      "integrity": "sha512-N8tnynqBdRzY8m2blPAnLUtaln0m8gb96q6ipnY+XoHQ3Z6uZoUq8jWAeFDhD+MCzM7qD2HyBDN7sEqiwMRO/g==",
-      "dev": true,
-      "optional": true
-    },
     "@swc/core-linux-x64-gnu": {
       "version": "1.3.39",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.39.tgz",
@@ -7790,27 +8039,6 @@
       "version": "1.3.39",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.39.tgz",
       "integrity": "sha512-ZiGERr/mdsEwfSiWn2Qokd8a4TTJkLVta6Nan39Bozo6J789u4uDF9Cj5TWWMSanHYAK/oRDaUm1yo2/DSecAA==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.39.tgz",
-      "integrity": "sha512-eUAk12LZ6RQHhe0ikZZsi0CPbRA6qsvoNQQ/6uwVF60CT0UnJrLiX3w3q30aXK3WjVR6uUlVEn7ze5t7HUeGyQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.39.tgz",
-      "integrity": "sha512-c3MIt+0gvZD0hmPOyoIJtdgx1ubP7E+uUnljw2+Nk8rO6qhIrWI08tWRNbT0HNLXHfHhKMJHvSAg3DGW8vG3Rg==",
-      "dev": true,
-      "optional": true
-    },
-    "@swc/core-win32-x64-msvc": {
-      "version": "1.3.39",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.39.tgz",
-      "integrity": "sha512-c4xGToLavhHjrE0Um0GyXCilL3sKNRP71GgQTVvqTFHxMmdUCBdug28olMDE1gYsCqXHaF6rPtg3QmD6dhTzKQ==",
       "dev": true,
       "optional": true
     },
@@ -7831,6 +8059,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -7991,8 +8228,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-3.0.2.tgz",
       "integrity": "sha512-6nTkYKaKFtzR9mWv1kCGVpM4U2r30tQiuSbQuMMJyOCMKnPhg1JTYcJoPOR8RLsQgI/12NkE8FHi60gP3FzLBw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "async-hook-jl": {
       "version": "1.7.6",
@@ -8028,6 +8264,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "big-integer": {
@@ -8119,6 +8361,16 @@
         "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-more-ints": {
@@ -8782,6 +9034,18 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -8971,13 +9235,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -9138,6 +9395,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -10241,6 +10504,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -10446,6 +10715,12 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rotating-file-stream": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.1.1.tgz",
+      "integrity": "sha512-PNF1iDkxcZG+T87uUzLlcO4aquTCyY8yl+Q/OTK4dMwhwWDYWU4ZATYeIXHmYVGIzqZ2MrpY4WIkYc9Bsc3Nzw==",
+      "dev": true
     },
     "run-script-os": {
       "version": "1.1.6",
@@ -10836,6 +11111,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@contrast/agent": "^4.32.13",
     "@contrast/protect-agent": "^5.7.0",
-    "@contrast/rasp-v3": "^0.5.0",
+    "@contrast/rasp-v3": "^0.7.0-alpha.2",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "shimmer": "^1.2.1"
   },
   "devDependencies": {
-    "@contrast/agent": "^4.19.2",
+    "@contrast/agent": "^4.32.13",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@contrast/agent": "^4.32.13",
+    "@contrast/protect-agent": "^5.7.0",
+    "@contrast/rasp-v3": "^0.5.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.32.0",

--- a/scripts/generate-route-entries.js
+++ b/scripts/generate-route-entries.js
@@ -3,6 +3,9 @@
 
 /**
  * tool to hit various end points on a server for testing and demos.
+ *
+ * the express and simple in test/servers/ implement these end points. run
+ * either using `node test/servers/express.js http:localhost:8888
  */
 
 const fs = require('fs');
@@ -53,8 +56,8 @@ for (let i = 0; i < args.length; i++) {
 if (requests.length === 0) {
   const ep = targets.map(t => t.ep.slice(1));
   /* eslint-disable */
-  console.log('usage: generate request...');
-  console.log('  valid requests', ep.join(', '));
+  console.log('usage: generate-route-entries target...');
+  console.log('  valid targets', ep.join(', '));
   console.log('  env vars=default: POOL=10, ITERATIONS, MIN=40, MAX=80');
   /* eslint-enable */
 

--- a/test-integration/servers-error-log.test.js
+++ b/test-integration/servers-error-log.test.js
@@ -85,7 +85,7 @@ describe('server error log tests', function() {
       });
 
       afterEach(function() {
-        if (!process.env.RM_DEBUG_TESTS) {
+        if (this.currentTest.state !== 'failed' || !process.env.RM_DEBUG_TESTS) {
           return;
         }
         const file = fs.readFileSync('route-metrics.log', 'utf8');

--- a/test-integration/servers-log.test.js
+++ b/test-integration/servers-log.test.js
@@ -84,10 +84,11 @@ describe('server log tests', function() {
       afterEach(function() {
         // if a test failed make it easier to debug how the server was created
         if (this.currentTest.state === 'failed') {
-          // eslint-disable no-console
+          /* eslint-disable no-console */
           console.log('new Server(', lastArgs, ')');
           console.log('last logLines', lastLogLines);
           console.log('last logEntries', logEntries.map(e => e.validator.show()));
+          /* eslint-enable no-console */
         }
       });
 

--- a/test-integration/servers-log.test.js
+++ b/test-integration/servers-log.test.js
@@ -42,6 +42,7 @@ describe('server log tests', function() {
     describe(desc, function() {
       this.timeout(10000);
       let lastArgs;
+      let lastLogLines;
       //
       // start the server
       //
@@ -83,8 +84,10 @@ describe('server log tests', function() {
       afterEach(function() {
         // if a test failed make it easier to debug how the server was created
         if (this.currentTest.state === 'failed') {
-          // eslint-disable-next-line no-console
+          // eslint-disable no-console
           console.log('new Server(', lastArgs, ')');
+          console.log('last logLines', lastLogLines);
+          console.log('last logEntries', logEntries.map(e => e.validator.show()));
         }
       });
 
@@ -101,8 +104,8 @@ describe('server log tests', function() {
           patch: patchEntries.length,
         };
         const {lines: logLines, linesNeeded} = await checks.waitForLines(typesNeeded);
+        lastLogLines = logLines;
 
-        // make sure all header and patch entries are present
         expect(logLines.length).gte(linesNeeded, 'not enough lines');
         const logObjects = logLines.map(line => JSON.parse(line));
 
@@ -127,6 +130,7 @@ describe('server log tests', function() {
           metrics: 3,
         };
         const {lines: logLines, linesNeeded} = await checks.waitForLines(typesNeeded);
+        lastLogLines = logLines;
 
         // make sure all header and patch entries are present
         expect(logLines.length).gte(linesNeeded, 'not enough lines');
@@ -155,6 +159,7 @@ describe('server log tests', function() {
           patch: patchEntries.length,
         };
         const {lines: logLines, linesNeeded} = await checks.waitForLines(typesNeeded);
+        lastLogLines = logLines;
 
         // make sure all header and patch entries are present
         expect(logLines.length).gte(linesNeeded, 'not enough lines');

--- a/test-integration/servers-log.test.js
+++ b/test-integration/servers-log.test.js
@@ -30,12 +30,8 @@ describe('server log tests', function() {
   //
   for (const t of tests()) {
     let testServer;
-
-    // build the array of expected log entries.
-    const logEntries = [makeLogEntryChecker('header', pdj)];
-    const patchEntries = makePatchEntryCheckers(t);
-    logEntries.push(...patchEntries);
-    logEntries.push(...metricsEntries);
+    let logEntries;
+    let patchEntries;
 
     const {server, base, desc, nodeArgs, appArgs} = t;
 
@@ -79,6 +75,15 @@ describe('server log tests', function() {
               expect(signal).equal(code);
             }
           });
+      });
+
+      beforeEach(function() {
+        // build the array of expected log entries. these need to be done
+        // each test because a patch entry is removed after it's been checked.
+        logEntries = [makeLogEntryChecker('header', pdj)];
+        patchEntries = makePatchEntryCheckers(t);
+        logEntries.push(...patchEntries);
+        logEntries.push(...metricsEntries);
       });
 
       afterEach(function() {

--- a/test-integration/servers-responses.test.js
+++ b/test-integration/servers-responses.test.js
@@ -76,7 +76,11 @@ describe('server response tests', function() {
             if (t.agentPresent) {
               expect(result.agent).equal(true, 'agent should be loaded');
               expect(result.tracker).equal(true, 'tracker should be present');
-              expect(result.tracked).equal(server === 'express', 'the data should be tracked');
+              // the released version of rasp-v3 does not have JSON string tracking, which
+              // this depends on. needs a new release of rasp-v3.
+              if (server === 'express' && t.agentPresent !== '@contrast/rasp-v3') {
+                expect(result.tracked).equal(server === 'express', 'the data should be tracked');
+              }
             } else {
               expect(result).property('agent').false;
               expect(result).property('tracker').false;

--- a/test-integration/servers-responses.test.js
+++ b/test-integration/servers-responses.test.js
@@ -76,11 +76,7 @@ describe('server response tests', function() {
             if (t.agentPresent) {
               expect(result.agent).equal(true, 'agent should be loaded');
               expect(result.tracker).equal(true, 'tracker should be present');
-              // the released version of rasp-v3 does not have JSON string tracking, which
-              // this depends on. needs a new release of rasp-v3.
-              if (server === 'express' && t.agentPresent !== '@contrast/rasp-v3') {
-                expect(result.tracked).equal(server === 'express', 'the data should be tracked');
-              }
+              expect(result.tracked).equal(server === 'express', 'the data should be tracked');
             } else {
               expect(result).property('agent').false;
               expect(result).property('tracker').false;

--- a/test-integration/servers-time-series.test.js
+++ b/test-integration/servers-time-series.test.js
@@ -69,13 +69,6 @@ describe('server time-series tests', function() {
       // start the server
       //
       before(async function() {
-        // ignore the log entries created by the test generator. they do not
-        // take header overrides into account; the original implementation
-        // still works but should be replaced by explicit construction of the
-        // expected log entries.
-        expectedLogEntries.push(makeLogEntryChecker('header', pdj, overrides));
-        expectedLogEntries.push(...makePatchEntryCheckers(t));
-
         // don't wait so long
         process.env.CSI_ROUTE_METRICS_TIME_SERIES_INTERVAL = 100;
         process.env.CSI_ROUTE_METRICS_AVERAGING_INTERVAL = 250;
@@ -112,6 +105,16 @@ describe('server time-series tests', function() {
               expect(signal).equal(code);
             }
           });
+      });
+
+      beforeEach(function() {
+        // ignore the log entries created by the test generator. they do not
+        // take header overrides into account; the original implementation
+        // still works but should be replaced by explicit construction of the
+        // expected log entries.
+        expectedLogEntries.length = 0;
+        expectedLogEntries.push(makeLogEntryChecker('header', pdj, overrides));
+        expectedLogEntries.push(...makePatchEntryCheckers(t));
       });
 
       afterEach(function() {

--- a/test/checks.js
+++ b/test/checks.js
@@ -306,15 +306,18 @@ function makePatchEntryCheckers(t) {
   const expressPresent = t.server === 'express';
 
   // the expected sequence of patches is specific to each combination of agent and
-  // express. @contrast/protect-agent needs to be added.
+  // express. @contrast/protect-agent needs to be added. N.B. as of node 16.19.1,
+  // the agent cannot be detected by route-metrics, because it is being loaded via
+  // the '-r' or '--request' command line opion. so it is being detected by looking
+  // at process.execArgv when the first module in the @contrast scope is loaded.
   if (t.agentPresent === '@contrast/agent') {
     // http is required first because, even though the node agent is loaded first,
     // it requires http before it completes loading, and patch events are only emitted
     // once patching is completed.
     //
-    // as of v4.?.? the agent also requires axios, which requires https, so next there is
-    // a patch entry for the contrast node-agent then one for https when axios eventually
-    // requires it.
+    // also, as of v4.?.? the agent also requires axios, which requires https, so next
+    // there is a patch entry for the contrast node-agent then one for https when axios
+    // eventually requires it.
     checkers.push(patchHttp);
     checkers.push(makeLogEntryChecker('patch', t.agentPresent));
     checkers.push(patchHttps);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 const util = require('util');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,7 +4,7 @@ const util = require('util');
 const {AGENTS} = require('../lib/patcher');
 
 const defaultEnv = {
-  CONTRAST_DEV: true
+  CONTRAST_DEV: true,
 };
 
 const defaultOptions = {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const {AGENTS} = require('../lib/patcher');
 
 const defaultEnv = {
   CONTRAST_DEV: true
@@ -37,7 +38,9 @@ function makeTestGenerator(opts) {
   const nodeArgs = {nodeArgs: [
     {desc: 'nothing', args: []},
     {desc: 'route-metrics only', args: ['-r', routeMetrics]},
-    {desc: 'route-metrics + agent', args: ['-r', routeMetrics, '-r', '@contrast/agent']},
+    {desc: 'route-metrics + node agent', args: ['-r', routeMetrics, '-r', '@contrast/agent']},
+    //{desc: 'route-metrics + node mono', args: ['-r', routeMetrics, '-r', '@contrast/protect-agent']},
+    {desc: 'route-metrics + rasp-v3', args: ['-r', routeMetrics, '-r', '@contrast/rasp-v3']},
   ]};
 
   const env = {env: getEnv(defaultEnv)};
@@ -76,7 +79,8 @@ function makeTestGenerator(opts) {
         throw new Error(`loadProtos ${t.loadProtos.join(', ')} doesn't contain ${t.protocol}`);
       }
 
-      t.agentPresent = t.nodeArgs[t.nodeArgs.length - 1] === '@contrast/agent';
+      const ix = AGENTS.indexOf(t.nodeArgs[t.nodeArgs.length - 1]);
+      t.agentPresent = ix >= 0 && AGENTS[ix];
 
       yield t;
     }

--- a/test/servers/express.js
+++ b/test/servers/express.js
@@ -5,10 +5,13 @@ const Server = require('./skeleton');
 const {
   __contrast: raspAgent,
   contrast_agent: nodeAndProtectAgent,
-  contrast_tracker: tracker
+  contrast_tracker: nodeAndProtectTracker
 } = global;
 
+const raspTracker = raspAgent?.tracking;
+
 const agent = raspAgent || nodeAndProtectAgent;
+const tracker = raspTracker || nodeAndProtectTracker;
 
 // the app
 const express = require('express');
@@ -53,7 +56,7 @@ echo.post('/meta', function(req, res, next) {
     tracker: !!tracker,
   };
   if (tracker) {
-    response.tracked = !!tracker.getData(s);
+    response.tracked = !!(tracker.getData || tracker.getMetadata)(s);
   }
   res.send(response);
 });

--- a/test/servers/express.js
+++ b/test/servers/express.js
@@ -2,7 +2,13 @@
 
 const Server = require('./skeleton');
 
-const {contrast_agent: agent, contrast_tracker: tracker} = global;
+const {
+  __contrast: raspAgent,
+  contrast_agent: nodeAndProtectAgent,
+  contrast_tracker: tracker
+} = global;
+
+const agent = raspAgent || nodeAndProtectAgent;
 
 // the app
 const express = require('express');

--- a/test/servers/express.js
+++ b/test/servers/express.js
@@ -2,16 +2,7 @@
 
 const Server = require('./skeleton');
 
-const {
-  __contrast: raspAgent,
-  contrast_agent: nodeAndProtectAgent,
-  contrast_tracker: nodeAndProtectTracker
-} = global;
-
-const raspTracker = raspAgent?.tracking;
-
-const agent = raspAgent || nodeAndProtectAgent;
-const tracker = raspTracker || nodeAndProtectTracker;
+const {agent, tracker} = Server.getAgentGlobals();
 
 // the app
 const express = require('express');

--- a/test/servers/simple.js
+++ b/test/servers/simple.js
@@ -2,7 +2,16 @@
 
 const Server = require('./skeleton');
 
-const {contrast_agent: agent, contrast_tracker: tracker} = global;
+const {
+  __contrast: raspAgent,
+  contrast_agent: nodeAndProtectAgent,
+  contrast_tracker: nodeAndProtectTracker
+} = global;
+
+const raspTracker = raspAgent?.tracking;
+
+const agent = raspAgent || nodeAndProtectAgent;
+const tracker = raspTracker || nodeAndProtectTracker;
 
 function app(req, res) {
   res.statusCode = 200;
@@ -58,7 +67,7 @@ function dispatch(req, res, body) {
         tracker: !!tracker,
       };
       if (tracker) {
-        response.tracked = !!tracker.getData(s);
+        response.tracked = !!(tracker.getData || tracker.getMetadata)(s);
       }
       res.end(JSON.stringify(response));
       return;

--- a/test/servers/simple.js
+++ b/test/servers/simple.js
@@ -2,16 +2,7 @@
 
 const Server = require('./skeleton');
 
-const {
-  __contrast: raspAgent,
-  contrast_agent: nodeAndProtectAgent,
-  contrast_tracker: nodeAndProtectTracker
-} = global;
-
-const raspTracker = raspAgent?.tracking;
-
-const agent = raspAgent || nodeAndProtectAgent;
-const tracker = raspTracker || nodeAndProtectTracker;
+const {agent, tracker} = Server.getAgentGlobals();
 
 function app(req, res) {
   res.statusCode = 200;

--- a/test/servers/skeleton.js
+++ b/test/servers/skeleton.js
@@ -97,4 +97,22 @@ ServerSkeleton.getProtocols = function(args) {
   return protocols;
 };
 
+//
+// helper for getting the the agent-specific global object and components
+//
+ServerSkeleton.getAgentGlobals = function() {
+  const {
+    __contrast: raspAgent,
+    contrast_agent: nodeAndProtectAgent,
+    contrast_tracker: nodeAndProtectTracker
+  } = global;
+
+  const raspTracker = raspAgent?.tracking;
+
+  const agent = raspAgent || nodeAndProtectAgent;
+  const tracker = raspTracker || nodeAndProtectTracker;
+
+  return {agent, tracker};
+};
+
 module.exports = ServerSkeleton;


### PR DESCRIPTION
- handle node's change that makes `-r` command line requires unhookable.
- update to rasp-v3@v0.7.0-alpha.2 (public)
- change patch-entry test logic to be order-independent
- add support for rasp-v3 and partial support for protect-agent (node-mono)